### PR TITLE
Change default value of option ensure_role_set to false

### DIFF
--- a/lib/pg_saurus/config.rb
+++ b/lib/pg_saurus/config.rb
@@ -6,7 +6,7 @@ module PgSaurus
 
     # Instantiate and set default config settings.
     def initialize
-      @ensure_role_set = true
+      @ensure_role_set = false
     end
   end
 end


### PR DESCRIPTION
## Changes

Set default value of `ensure_role_set` to false. It's supposed to be from the begining, but I have forgotten to fix it.
## RSpec

```
Finished in 1.31 seconds (files took 1.49 seconds to load)
159 examples, 0 failures, 2 pending
```
