### PR TITLE
Support database triggers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,8 @@ ActiveRecord extension to get more from PostgreSQL:
 * Use foreign keys.
 * Use partial indexes.
 * Run index creation concurrently.
+* Create/drop functions.
+* Create/drop triggers.
 
 PgSaurus is a fork of PgPower.
 
@@ -317,6 +319,7 @@ You can create, list, and drop functions.
 ### Examples
 
 ```ruby
+# Create a function
 pets_not_empty_function = <<-SQL
 BEGIN
   IF (SELECT COUNT(*) FROM pets) > 0
@@ -327,13 +330,39 @@ BEGIN
   END IF;
 END;
 SQL
-
+# Arguments are: function_name, return_type, function_definition, options (currently, only :schema)
 create_function 'pets_not_empty()', :boolean, pets_not_empty_function, schema: 'public'
-functions.any?{ |function| function.name == 'public.pets_not_empty()' }
-# => true
+
+# Drop a function
 drop_function 'pets_not_empty()'
-functions.any?{ |function| function.name == 'public.pets_not_empty()' }
-# => false
+
+# Get a list of defined functions
+ActiveRecord::Base.connection.functions
+```
+
+## Triggers
+
+You can create and remove triggers on tables and views.
+
+### Examples
+
+```ruby
+# Create a trigger
+create_trigger :pets,                           # Table or view name
+               :pets_not_empty_trigger_proc,    # Procedure name. Parentheses are optional if you have no arguments.
+               'AFTER INSERT',                  # Trigger event
+               for_each: 'ROW',                 # Can be row or statement. Default is row.
+               schema: 'public',                # Optional schema name
+               constraint: true,                # Sets if the trigger is a constraint. Default is false.
+               deferrable: true,                # Sets if the trigger is immediate or deferrable. Default is immediate.
+               initially_deferred: true,        # Sets if the trigger is initially deferred. Default is immediate. Only relevant if the trigger is deferrable.
+               condition: "new.name = 'fluffy'" # Optional when condition. Default is none.
+
+# Drop a trigger
+remove_trigger :pets, :pets_not_empty_trigger_proc
+
+# Get a list of defined triggers on a table or view
+ActiveRecord::Base.connection.triggers
 ```
 
 ## Tools
@@ -375,6 +404,10 @@ PgSaurus does not support Rails 3.
 * Done!
 
 ## TODO:
+
+Support for Rails 4.2+
+
+* This will likely necessitate a major rewrite.
 
 Support for JRuby:
 

--- a/lib/pg_saurus/connection_adapters.rb
+++ b/lib/pg_saurus/connection_adapters.rb
@@ -7,4 +7,5 @@ module PgSaurus::ConnectionAdapters # :nodoc:
   autoload :ForeignKeyDefinition
   autoload :IndexDefinition, 'pg_saurus/connection_adapters/index_definition'
   autoload :FunctionDefinition, 'pg_saurus/connection_adapters/function_definition'
+  autoload :TriggerDefinition, 'pg_saurus/connection_adapters/trigger_definition'
 end

--- a/lib/pg_saurus/connection_adapters/abstract_adapter.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter.rb
@@ -8,12 +8,14 @@ module PgSaurus::ConnectionAdapters::AbstractAdapter
   autoload :SchemaMethods
   autoload :IndexMethods
   autoload :FunctionMethods
+  autoload :TriggerMethods
 
   include CommentMethods
   include ForeignerMethods
   include SchemaMethods
   include IndexMethods
   include FunctionMethods
+  include TriggerMethods
 
   included do
     alias_method_chain :create_table, :schema_option

--- a/lib/pg_saurus/connection_adapters/abstract_adapter/function_methods.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter/function_methods.rb
@@ -7,11 +7,33 @@ module PgSaurus::ConnectionAdapters::AbstractAdapter::FunctionMethods
   end
 
   # Create a database function.
+  #
+  # Example:
+  #
+  #   # Arguments are: function_name, return_type, function_definition, options (currently, only :schema)
+  #   create_function 'pets_not_empty()', :boolean, <<-FUNCTION, schema: 'public'
+  #     BEGIN
+  #       IF (SELECT COUNT(*) FROM pets) > 0
+  #       THEN
+  #       RETURN true;
+  #       ELSE
+  #       RETURN false;
+  #      END IF;
+  #       END;
+  #     FUNCTION
+  #
+  # The schema is optional.
   def create_function(function_name, returning, definition, options = {})
 
   end
 
   # Delete the database function.
+  #
+  # Example:
+  #
+  #   drop_function 'pets_not_empty()', schema: 'public'
+  #
+  # The schema is optional.
   def drop_function(function_name, options)
 
   end

--- a/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods.rb
@@ -15,14 +15,15 @@ module PgSaurus::ConnectionAdapters::AbstractAdapter::TriggerMethods
   #
   # Example:
   #
-  #   create_trigger :pets,
-  #                  :pets_not_empty_trigger_proc,
-  #                  'AFTER INSERT',
-  #                  for_each: 'ROW',
-  #                  schema: 'public',
-  #                  constraint: true,
-  #                  deferrable: true,
-  #                  initially_deferred: true
+  #   create_trigger :pets,                           # Table or view name
+  #                  :pets_not_empty_trigger_proc,    # Procedure name. Parentheses are optional if you have no arguments.
+  #                  'AFTER INSERT',                  # Trigger event
+  #                  for_each: 'ROW',                 # Can be row or statement. Default is row.
+  #                  schema: 'public',                # Optional schema name
+  #                  constraint: true,                # Sets if the trigger is a constraint. Default is false.
+  #                  deferrable: true,                # Sets if the trigger is immediate or deferrable. Default is immediate.
+  #                  initially_deferred: true,        # Sets if the trigger is initially deferred. Default is immediate. Only relevant if the trigger is deferrable.
+  #                  condition: "new.name = 'fluffy'" # Optional when condition. Default is none.
   #
   def create_trigger(table_name, proc_name, event, options = {})
 

--- a/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods.rb
@@ -1,0 +1,22 @@
+# Adapter definitions for db functions
+module PgSaurus::ConnectionAdapters::AbstractAdapter::TriggerMethods
+
+  # :nodoc
+  def supports_triggers?
+    false
+  end
+
+  # Returns the listing of currently defined db triggers
+  def triggers
+
+  end
+
+  def create_trigger(table_name, proc_name, event, options = {})
+
+  end
+
+  def remove_trigger(table_name, proc_name, options = {})
+
+  end
+
+end

--- a/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods.rb
@@ -11,10 +11,29 @@ module PgSaurus::ConnectionAdapters::AbstractAdapter::TriggerMethods
 
   end
 
+  # Creates a trigger.
+  #
+  # Example:
+  #
+  #   create_trigger :pets,
+  #                  :pets_not_empty_trigger_proc,
+  #                  'AFTER INSERT',
+  #                  for_each: 'ROW',
+  #                  schema: 'public',
+  #                  constraint: true,
+  #                  deferrable: true,
+  #                  initially_deferred: true
+  #
   def create_trigger(table_name, proc_name, event, options = {})
 
   end
 
+  # Removes a trigger.
+  #
+  # Example:
+  #
+  #   remove_trigger :pets, :pets_not_empty_trigger_proc
+  #
   def remove_trigger(table_name, proc_name, options = {})
 
   end

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter.rb
@@ -13,6 +13,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter
   autoload :TranslateException, 'pg_saurus/connection_adapters/postgresql_adapter/translate_exception'
   autoload :ViewMethods,        'pg_saurus/connection_adapters/postgresql_adapter/view_methods'
   autoload :FunctionMethods,    'pg_saurus/connection_adapters/postgresql_adapter/function_methods'
+  autoload :TriggerMethods,     'pg_saurus/connection_adapters/postgresql_adapter/trigger_methods'
 
   include ExtensionMethods
   include SchemaMethods
@@ -22,6 +23,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter
   include TranslateException
   include ViewMethods
   include FunctionMethods
+  include TriggerMethods
 
   included do
     alias_method_chain :tables, :non_public_schema_tables

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods.rb
@@ -102,7 +102,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::FunctionMethods
   # Write out the fully qualified function name if the :schema option is passed.
   def full_function_name(function_name, options)
     schema        = options[:schema]
-    function_name = "#{schema}.#{function_name}" if schema
+    function_name = "\"#{schema}\".#{function_name}" if schema
     function_name
   end
   private :full_function_name

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods.rb
@@ -1,0 +1,130 @@
+# Provides methods to extend {ActiveRecord::ConnectionAdapters::PostgreSQLAdapter}
+# to support db triggers.
+module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
+
+  # :nodoc
+  def supports_triggers?
+    true
+  end
+
+  def create_trigger(table_name, proc_name, event, options = {})
+    proc_name = "#{proc_name}"
+    proc_name = "#{proc_name}()" unless proc_name.end_with?(')')
+
+    for_each = options[:for_each] || 'ROW'
+    constraint = options[:constraint]
+
+    sql = if constraint
+            "CREATE CONSTRAINT TRIGGER #{trigger_name(proc_name, options)}\n  #{event}\n"
+          else
+            "CREATE TRIGGER #{trigger_name(proc_name, options)}\n  #{event}\n"
+          end
+
+    sql << "  ON #{quote_table_or_view(table_name, options)}\n"
+    if constraint
+      sql << if options[:deferrable]
+               "  DEFERRABLE INITIALLY #{!!options[:initially_deferred] ? 'DEFERRED' : 'IMMEDIATE'}\n"
+             else
+               "  NOT DEFERRABLE\n"
+             end
+    end
+    sql << "  FOR EACH #{for_each}\n"
+    if condition = options[:condition]
+      sql << "  WHEN (#{condition})\n"
+    end
+    sql << "  EXECUTE PROCEDURE #{proc_name}"
+
+    execute sql
+  end
+
+  def remove_trigger(table_name, proc_name, options = {})
+    execute "DROP TRIGGER #{trigger_name(proc_name, options)} ON #{quote_table_or_view(table_name, options)}"
+  end
+
+  # Returns the listing of currently defined db triggers
+  def triggers
+    res = select_all <<-SQL
+      SELECT n.nspname as schema,
+             c.relname as table,
+             t.tgname as trigger_name,
+             t.tgenabled as enable_mode,
+             t.tgdeferrable as is_deferrable,
+             t.tginitdeferred as is_initially_deferrable,
+             pg_catalog.pg_get_triggerdef(t.oid, true) as trigger_definition
+      FROM pg_catalog.pg_trigger t
+        INNER JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+        INNER JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind IN ('r', 'v')
+        AND NOT t.tgisinternal
+      ORDER BY 1, 2, 3;
+    SQL
+
+    res.inject([]) do |buffer, row|
+      schema                = row['schema']
+      table                 = row['table']
+      trigger_name          = row['trigger_name']
+      is_deferrable         = row['is_deferrable']
+      is_initially_deferred = row['is_initially_deferred']
+
+      trigger_definition = row['trigger_definition']
+
+      is_constraint = is_constraint?(trigger_definition)
+      proc_name     = parse_proc_name(trigger_definition)
+      event         = parse_event(trigger_definition, trigger_name)
+      condition     = parse_condition(trigger_definition)
+
+      for_every = !!(trigger_definition =~ /FOR[\s]EACH[\s]ROW/) ? :row : :statement
+
+      if proc_name && event
+        buffer << ::PgSaurus::ConnectionAdapters::TriggerDefinition.new(
+          trigger_name,
+          proc_name,
+          is_constraint,
+          event,
+          for_every,
+          is_deferrable,
+          is_initially_deferred,
+          condition,
+          table,
+          schema
+        )
+      end
+      buffer
+    end
+  end
+
+  def parse_condition(trigger_definition)
+    trigger_definition[/WHEN[\s](.*?)[\s]EXECUTE[\s]PROCEDURE/m, 1]
+  end
+
+  def parse_event(trigger_definition, trigger_name)
+    trigger_definition[/^CREATE[\sA-Z]+TRIGGER[\s]#{Regexp.escape(trigger_name)}[\s](.*?)[\s]ON[\s]/m, 1]
+  end
+
+  def parse_proc_name(trigger_definition)
+    trigger_definition[/EXECUTE[\s]PROCEDURE[\s](.*?)$/m,1]
+  end
+
+  def is_constraint?(trigger_definition)
+    !!(trigger_definition =~ /^CREATE CONSTRAINT TRIGGER/)
+  end
+  private :is_constraint?
+
+  def quote_table_or_view(name, options)
+    schema = options[:schema]
+    if schema
+      "\"#{schema}\".\"#{name}\""
+    else
+      "\"#{name}\""
+    end
+  end
+
+  def trigger_name(proc_name, options)
+    if name = options[:name]
+      name
+    else
+      "trigger_#{proc_name.gsub('(', '').gsub(')', '')}"
+    end
+  end
+
+end

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods.rb
@@ -7,6 +7,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
     true
   end
 
+  # See lib/pg_saurus/connection_adapters/trigger_methods.rb
   def create_trigger(table_name, proc_name, event, options = {})
     proc_name = "#{proc_name}"
     proc_name = "#{proc_name}()" unless proc_name.end_with?(')')
@@ -37,11 +38,14 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
     execute sql
   end
 
+  # See lib/pg_saurus/connection_adapters/trigger_methods.rb
   def remove_trigger(table_name, proc_name, options = {})
     execute "DROP TRIGGER #{trigger_name(proc_name, options)} ON #{quote_table_or_view(table_name, options)}"
   end
 
   # Returns the listing of currently defined db triggers
+  #
+  # @return [Array<::PgSaurus::ConnectionAdapters::TriggerDefinition>]
   def triggers
     res = select_all <<-SQL
       SELECT n.nspname as schema,
@@ -96,14 +100,17 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
   def parse_condition(trigger_definition)
     trigger_definition[/WHEN[\s](.*?)[\s]EXECUTE[\s]PROCEDURE/m, 1]
   end
+  private :parse_condition
 
   def parse_event(trigger_definition, trigger_name)
     trigger_definition[/^CREATE[\sA-Z]+TRIGGER[\s]#{Regexp.escape(trigger_name)}[\s](.*?)[\s]ON[\s]/m, 1]
   end
+  private :parse_event
 
   def parse_proc_name(trigger_definition)
     trigger_definition[/EXECUTE[\s]PROCEDURE[\s](.*?)$/m,1]
   end
+  private :parse_proc_name
 
   def is_constraint?(trigger_definition)
     !!(trigger_definition =~ /^CREATE CONSTRAINT TRIGGER/)
@@ -118,6 +125,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
       "\"#{name}\""
     end
   end
+  private :quote_table_or_view
 
   def trigger_name(proc_name, options)
     if name = options[:name]
@@ -126,5 +134,6 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
       "trigger_#{proc_name.gsub('(', '').gsub(')', '')}"
     end
   end
+  private :trigger_name
 
 end

--- a/lib/pg_saurus/connection_adapters/table.rb
+++ b/lib/pg_saurus/connection_adapters/table.rb
@@ -6,10 +6,11 @@ module PgSaurus::ConnectionAdapters::Table
 
   autoload :CommentMethods
   autoload :ForeignerMethods
+  autoload :TriggerMethods
 
   include CommentMethods
   include ForeignerMethods
-
+  include TriggerMethods
 
   included do
     alias_method_chain :references, :foreign_keys

--- a/lib/pg_saurus/connection_adapters/table/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/table/trigger_methods.rb
@@ -1,0 +1,33 @@
+# Provides methods to extend ActiveRecord::ConnectionAdapters::Table
+# to support database triggers.
+module PgSaurus::ConnectionAdapters::Table::TriggerMethods
+
+  # Creates a trigger.
+  #
+  # Example:
+  #
+  #   change_table :pets do |t|
+  #     t.create_trigger :pets_not_empty_trigger_proc,
+  #                      'AFTER INSERT',
+  #                      for_each: 'ROW',
+  #                      schema: 'public',
+  #                      constraint: true,
+  #                      deferrable: true,
+  #                      initially_deferred: true
+  #   end
+  def create_trigger(proc_name, event, options = {})
+    @base.create_trigger(@table_name, proc_name, event, options)
+  end
+
+  # Removes a trigger.
+  #
+  # Example:
+  #
+  #   change_table :pets do |t|
+  #     t.remove_trigger :pets_not_empty_trigger_proc
+  #   end
+  def remove_trigger(proc_name, options = {})
+    @base.remove_trigger(@table_name, proc_name, options)
+  end
+
+end

--- a/lib/pg_saurus/connection_adapters/trigger_definition.rb
+++ b/lib/pg_saurus/connection_adapters/trigger_definition.rb
@@ -1,0 +1,16 @@
+module PgSaurus::ConnectionAdapters
+
+  # Struct definition for a db trigger
+  class TriggerDefinition < Struct.new( :name,
+                                        :proc_name,
+                                        :constraint,
+                                        :event,
+                                        :for_each,
+                                        :deferrable,
+                                        :initially_deferred,
+                                        :condition,
+                                        :table,
+                                        :schema )
+
+  end
+end

--- a/lib/pg_saurus/migration/command_recorder.rb
+++ b/lib/pg_saurus/migration/command_recorder.rb
@@ -9,6 +9,7 @@ module PgSaurus::Migration::CommandRecorder
   autoload :ForeignerMethods
   autoload :ViewMethods
   autoload :FunctionMethods
+  autoload :TriggerMethods
 
   include ExtensionMethods
   include SchemaMethods
@@ -16,4 +17,5 @@ module PgSaurus::Migration::CommandRecorder
   include ForeignerMethods
   include ViewMethods
   include FunctionMethods
+  include TriggerMethods
 end

--- a/lib/pg_saurus/migration/command_recorder/function_methods.rb
+++ b/lib/pg_saurus/migration/command_recorder/function_methods.rb
@@ -1,15 +1,15 @@
 # Methods to extend ActiveRecord::Migration::CommandRecorder to
-# support comments feature.
+# support database functions.
 module  PgSaurus::Migration::CommandRecorder::FunctionMethods
 
   # :nodoc
   def create_function(*args)
-    record :create_function, *args
+    record :create_function, args
   end
 
   # :nodoc
   def drop_function(*args)
-    record :drop_function, *args
+    record :drop_function, args
   end
 
   # :nodoc

--- a/lib/pg_saurus/migration/command_recorder/trigger_methods.rb
+++ b/lib/pg_saurus/migration/command_recorder/trigger_methods.rb
@@ -1,0 +1,23 @@
+# Methods to extend ActiveRecord::Migration::CommandRecorder to
+# support database triggers.
+module PgSaurus::Migration::CommandRecorder::TriggerMethods
+
+  # :nodoc:
+  def create_trigger(*args)
+    record :create_trigger, args
+  end
+
+  # :nodoc:
+  def remove_trigger(*args)
+    record :remove_trigger, args
+  end
+
+  # :nodoc:
+  def invert_create_trigger(args)
+    table_name, proc_name, _, options = *args
+    options ||= {}
+
+    [:remove_trigger, [table_name, proc_name, options]]
+  end
+
+end

--- a/lib/pg_saurus/schema_dumper.rb
+++ b/lib/pg_saurus/schema_dumper.rb
@@ -11,6 +11,7 @@ module PgSaurus::SchemaDumper
   autoload :ForeignerMethods
   autoload :ViewMethods
   autoload :FunctionMethods
+  autoload :TriggerMethods
 
   include ExtensionMethods
   include CommentMethods
@@ -18,6 +19,7 @@ module PgSaurus::SchemaDumper
   include ForeignerMethods
   include ViewMethods
   include FunctionMethods
+  include TriggerMethods
 
   included do
     alias_method_chain :header, :schemas
@@ -26,6 +28,7 @@ module PgSaurus::SchemaDumper
     alias_method_chain :tables, :views
     alias_method_chain :tables, :foreign_keys
     alias_method_chain :tables, :functions
+    alias_method_chain :tables, :triggers
     alias_method_chain :tables, :comments
   end
 end

--- a/lib/pg_saurus/schema_dumper/trigger_methods.rb
+++ b/lib/pg_saurus/schema_dumper/trigger_methods.rb
@@ -24,9 +24,9 @@ module PgSaurus::SchemaDumper::TriggerMethods
         " schema: '#{trigger.schema}'"
 
       if trigger.condition
-        statement << ", condition: '#{trigger.condition}'"
+        statement << ", condition: '#{trigger.condition.gsub("'", %q(\\\'))}'"
       end
-
+puts statement
       stream.puts "#{statement}\n"
     end
   end

--- a/lib/pg_saurus/schema_dumper/trigger_methods.rb
+++ b/lib/pg_saurus/schema_dumper/trigger_methods.rb
@@ -1,0 +1,48 @@
+# Support for dumping database triggers
+module PgSaurus::SchemaDumper::TriggerMethods
+
+  # :nodoc
+  def tables_with_triggers(stream)
+    tables_without_triggers(stream)
+
+    dump_triggers(stream)
+    stream.puts
+
+    stream
+  end
+
+  # Writes out a command to create each detected trigger
+  def dump_triggers(stream)
+    #
+    @connection.triggers.each do |trigger|
+      statement = "  create_trigger '#{trigger.table}', '#{trigger.proc_name}', '#{trigger.event}',"\
+        " name: '#{trigger.name}',"\
+        " constraint: #{trigger.constraint ? :true : :false},"\
+        " for_each: :#{trigger.for_each},"\
+        " deferrable: #{trigger.deferrable ? :true : :false},"\
+        " initially_deferred: #{trigger.initially_deferred ? :true : :false},"\
+        " schema: '#{trigger.schema}'"
+
+      if trigger.condition
+        statement << ", condition: '#{trigger.condition}'"
+      end
+
+      stream.puts "#{statement}\n"
+    end
+  end
+=begin
+class TriggerDefinition < Struct.new( :name,
+                                        :proc_name,
+                                        :constraint,
+                                        :event,
+                                        :for_each,
+                                        :deferrable,
+                                        :initially_deferred,
+                                        :condition,
+                                        :table,
+                                        :schema )
+
+  end
+=end
+
+end

--- a/lib/pg_saurus/schema_dumper/trigger_methods.rb
+++ b/lib/pg_saurus/schema_dumper/trigger_methods.rb
@@ -26,23 +26,9 @@ module PgSaurus::SchemaDumper::TriggerMethods
       if trigger.condition
         statement << ", condition: '#{trigger.condition.gsub("'", %q(\\\'))}'"
       end
-puts statement
+
       stream.puts "#{statement}\n"
     end
   end
-=begin
-class TriggerDefinition < Struct.new( :name,
-                                        :proc_name,
-                                        :constraint,
-                                        :event,
-                                        :for_each,
-                                        :deferrable,
-                                        :initially_deferred,
-                                        :condition,
-                                        :table,
-                                        :schema )
-
-  end
-=end
 
 end

--- a/spec/active_record/schema_dumper_spec.rb
+++ b/spec/active_record/schema_dumper_spec.rb
@@ -116,6 +116,12 @@ describe ActiveRecord::SchemaDumper do
       end
     end
 
+    context 'Triggers' do
+      it 'dumps trigger definitions' do
+        @dump.should =~ /create_trigger 'pets', 'pets_not_empty_trigger_proc\(\)', 'AFTER INSERT'/
+      end
+    end
+
     context 'Comments' do
       it 'dumps table comments' do
         @dump.should =~ /set_table_comment 'users', 'Information about users'/

--- a/spec/dummy/db/migrate/20150714003209_create_pets_trigger.rb
+++ b/spec/dummy/db/migrate/20150714003209_create_pets_trigger.rb
@@ -6,18 +6,6 @@ class CreatePetsTrigger < ActiveRecord::Migration
       END;
     FUNCTION
 
-    # DROP TRIGGER trigger_pets_not_empty_trigger ON pets;
-=begin
-    execute <<-SQL
-create CONSTRAINT trigger trigger_pets_not_empty_trigger
-  after insert
-  ON "pets"
-  DEFERRABLE INITIALLY DEFERRED
-  FOR EACH ROW
-  EXECUTE PROCEDURE pets_not_empty_trigger();
-    SQL
-=end
-
     create_trigger :pets,
                    :pets_not_empty_trigger_proc,
                    'AFTER INSERT',
@@ -25,12 +13,13 @@ create CONSTRAINT trigger trigger_pets_not_empty_trigger
                    schema: 'public',
                    constraint: true,
                    deferrable: true,
-                   initially_deferred: true
+                   initially_deferred: true,
+                   condition: "new.name = 'fluffy'"
 
 
     change_table :pets do |t|
       t.create_trigger :pets_not_empty_trigger_proc,
-                       'AFTER INSERT',
+                       'AFTER INSERT OR UPDATE',
                        name: 'trigger_foo'
 
       t.remove_trigger nil, name: 'trigger_foo'

--- a/spec/dummy/db/migrate/20150714003209_create_pets_trigger.rb
+++ b/spec/dummy/db/migrate/20150714003209_create_pets_trigger.rb
@@ -1,0 +1,39 @@
+class CreatePetsTrigger < ActiveRecord::Migration
+  def change
+    create_function 'pets_not_empty_trigger_proc()', :trigger, <<-FUNCTION.gsub(/^[\s]{6}/, ""), schema: 'public'
+      BEGIN
+        RETURN null;
+      END;
+    FUNCTION
+
+    # DROP TRIGGER trigger_pets_not_empty_trigger ON pets;
+=begin
+    execute <<-SQL
+create CONSTRAINT trigger trigger_pets_not_empty_trigger
+  after insert
+  ON "pets"
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW
+  EXECUTE PROCEDURE pets_not_empty_trigger();
+    SQL
+=end
+
+    create_trigger :pets,
+                   :pets_not_empty_trigger_proc,
+                   'AFTER INSERT',
+                   for_each: 'ROW',
+                   schema: 'public',
+                   constraint: true,
+                   deferrable: true,
+                   initially_deferred: true
+
+
+    change_table :pets do |t|
+      t.create_trigger :pets_not_empty_trigger_proc,
+                       'AFTER INSERT',
+                       name: 'trigger_foo'
+
+      t.remove_trigger nil, name: 'trigger_foo'
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713035548) do
+ActiveRecord::Schema.define(version: 20150714003209) do
 
   create_schema "demography"
   create_schema "later"
@@ -135,6 +135,14 @@ ActiveRecord::Schema.define(version: 20150713035548) do
       END IF;
     END;
   FUNCTION_DEFINITION
+
+  create_function 'public.pets_not_empty_trigger_proc()', :trigger, <<-FUNCTION_DEFINITION.gsub(/^[ ]{4}/, '')
+    BEGIN
+      RETURN null;
+    END;
+  FUNCTION_DEFINITION
+
+  create_trigger 'pets', 'pets_not_empty_trigger_proc()', 'AFTER INSERT', name: 'trigger_pets_not_empty_trigger_proc', constraint: true, for_each: :row, deferrable: true, initially_deferred: false, schema: 'public'
 
   set_table_comment 'demography.citizens', 'Citizens Info'
   set_column_comment 'demography.citizens', 'country_id', 'Country key'

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -142,7 +142,7 @@ ActiveRecord::Schema.define(version: 20150714003209) do
     END;
   FUNCTION_DEFINITION
 
-  create_trigger 'pets', 'pets_not_empty_trigger_proc()', 'AFTER INSERT', name: 'trigger_pets_not_empty_trigger_proc', constraint: true, for_each: :row, deferrable: true, initially_deferred: false, schema: 'public'
+  create_trigger 'pets', 'pets_not_empty_trigger_proc()', 'AFTER INSERT', name: 'trigger_pets_not_empty_trigger_proc', constraint: true, for_each: :row, deferrable: true, initially_deferred: false, schema: 'public', condition: '(new.name::text = \'fluffy\'::text)'
 
   set_table_comment 'demography.citizens', 'Citizens Info'
   set_column_comment 'demography.citizens', 'country_id', 'Country key'

--- a/spec/lib/pg_saurus/connection_adapters/abstract_adapter/function_methods_spec.rb
+++ b/spec/lib/pg_saurus/connection_adapters/abstract_adapter/function_methods_spec.rb
@@ -8,6 +8,6 @@ describe PgSaurus::ConnectionAdapters::AbstractAdapter::FunctionMethods do
   let(:adapter_stub) { AbstractAdapter.new }
 
   it ".supports_functions?" do
-    expect(adapter_stub.supports_comments?).to be false
+    expect(adapter_stub.supports_functions?).to be false
   end
 end

--- a/spec/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods_spec.rb
+++ b/spec/lib/pg_saurus/connection_adapters/abstract_adapter/trigger_methods_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe PgSaurus::ConnectionAdapters::AbstractAdapter::TriggerMethods do
+  class AbstractAdapter
+    include ::PgSaurus::ConnectionAdapters::AbstractAdapter::TriggerMethods
+  end
+
+  let(:adapter_stub) { AbstractAdapter.new }
+
+  it ".supports_functions?" do
+    expect(adapter_stub.supports_triggers?).to be false
+  end
+end

--- a/spec/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods_spec.rb
+++ b/spec/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods_spec.rb
@@ -12,7 +12,7 @@ describe PgSaurus::ConnectionAdapters::PostgreSQLAdapter::FunctionMethods do
 
     it "default behavior" do
       sql = <<-SQL.gsub(/^[ ]{8}/, "")
-        CREATE OR REPLACE FUNCTION public.pets_not_empty()
+        CREATE OR REPLACE FUNCTION "public".pets_not_empty()
           RETURNS boolean
           LANGUAGE plpgsql
         AS $function$

--- a/spec/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods_spec.rb
+++ b/spec/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods do
+
+  let(:connection) { ActiveRecord::Base.connection }
+
+  it ".supports_triggers?" do
+    expect(connection.supports_triggers?).to be true
+  end
+
+  context '.create_trigger' do
+
+    it 'executes a query to create a trigger' do
+      sql = <<-SQL.gsub(/^[ ]{8}/, "")
+        CREATE CONSTRAINT TRIGGER trigger_pets_not_empty_trigger_proc
+          AFTER INSERT
+          ON "public"."pets"
+          DEFERRABLE INITIALLY DEFERRED
+          FOR EACH ROW
+          WHEN (name = 'Fluffy')
+          EXECUTE PROCEDURE pets_not_empty_trigger_proc()
+      SQL
+
+      expect(connection).to receive(:execute).with(sql.strip)
+
+      connection.create_trigger :pets,
+                     :pets_not_empty_trigger_proc,
+                     'AFTER INSERT',
+                     for_each: 'ROW',
+                     schema: 'public',
+                     constraint: true,
+                     deferrable: true,
+                     initially_deferred: true,
+                     condition: "name = 'Fluffy'"
+    end
+
+  end
+
+  context '.remove_trigger' do
+
+    it 'derive trigger name' do
+      expect(connection).to receive(:execute).with('DROP TRIGGER trigger_foo_bar ON "pets"')
+
+      connection.remove_trigger :pets, 'foo_bar()'
+    end
+
+    it 'explicitly named trigger' do
+      expect(connection).to receive(:execute).with('DROP TRIGGER trigger_foo_bar ON "pets"')
+
+      connection.remove_trigger :pets, 'foo_bar_baz', name: 'trigger_foo_bar'
+    end
+
+  end
+end

--- a/spec/lib/pg_saurus/connection_adapters/table/trigger_methods_spec.rb
+++ b/spec/lib/pg_saurus/connection_adapters/table/trigger_methods_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe PgSaurus::ConnectionAdapters::Table::TriggerMethods do
+  class AbstractTable
+    include ::PgSaurus::ConnectionAdapters::Table::TriggerMethods
+
+    def initialize
+      @base       = Object.new
+      @table_name = "sometable"
+    end
+
+  end
+
+  let(:table_stub) { AbstractTable.new }
+  let(:base)       { table_stub.instance_variable_get(:@base) }
+
+  it '.create_trigger' do
+    expect(base).to receive(:create_trigger).with('sometable', 'proc_name', 'event', {})
+
+    table_stub.create_trigger 'proc_name', 'event'
+  end
+
+  it '.remove_trigger' do
+    expect(base).to receive(:remove_trigger).with('sometable', 'proc_name', {})
+
+    table_stub.remove_trigger 'proc_name'
+  end
+
+end

--- a/spec/lib/pg_saurus/migration/command_recorder_spec.rb
+++ b/spec/lib/pg_saurus/migration/command_recorder_spec.rb
@@ -7,11 +7,30 @@ describe PgSaurus::Migration::CommandRecorder do
 
   let(:command_recorder_stub) { CommandRecorderStub.new }
 
+  describe 'Triggers' do
+
+    [ :create_trigger, :remove_trigger ].each do |method_name|
+      it ".#{method_name}" do
+        expect(command_recorder_stub).to receive(:record).with(method_name, [])
+        command_recorder_stub.send(method_name)
+      end
+    end
+
+    it '.invert_create_trigger' do
+      expect(
+        command_recorder_stub.invert_create_trigger(
+                               ['pets', 'pets_not_empty', 'AFTER CREATE', {}]
+        )
+      ).to eq([:remove_trigger, ['pets', 'pets_not_empty', {}]])
+    end
+
+  end
+
   describe 'Functions' do
 
     [ :create_function, :drop_function ].each do |method_name|
       it ".#{method_name}" do
-        expect(command_recorder_stub).to receive(:record).with(method_name)
+        expect(command_recorder_stub).to receive(:record).with(method_name, [])
         command_recorder_stub.send(method_name)
       end
     end


### PR DESCRIPTION
Task 5571

Adds support for creating, dropping and reading database triggers in migrations:

```ruby
create_trigger :pets, # Table or view name
               :pets_not_empty_trigger_proc, # Procedure name. Parentheses are optional if you have no arguments.
               'AFTER INSERT', # Trigger event
               for_each: 'ROW', # Can be row or statement. Default is row.
               schema: 'public', # Optional schema name
               constraint: true, # Sets if the trigger is a constraint. Default is false.
               deferrable: true, # Sets if the trigger is immediate or deferrable. Default is immediate.
               initially_deferred: true, # Sets if the trigger is initially deferred. Default is immediate. Only relevant if the trigger is deferrable.
               condition: "new.name = 'fluffy'" # Optional when condition. Default is none.

remove_trigger :pets, :pets_not_empty_trigger_proc
```

Also, extended the table object to support creating and dropping triggers:

```ruby
change_table :pets do |t|
  t.create_trigger :pets_not_empty_trigger_proc,
                   'AFTER INSERT OR UPDATE',
                   name: 'trigger_foo'

  t.remove_trigger nil, name: 'trigger_foo'
end
```