### PR TITLE
Issue 6 Enable schema support for enable_extension

### DIFF
--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
@@ -52,6 +52,20 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
     execute(sql)
   end
 
+  # Execute SQL to load a postgresql extension module into the current database
+  # if it does not already exist. Then reload the type map.
+  #
+  # @param [#to_s] extension_name Name of the extension module to load
+  # @param [Hash] options
+  # @option options [#to_s,nil] :schema_name The name of the schema in which to install the extension's objects
+  # @option options [#to_s,nil] :version The version of the extension to install
+  # @option options [#to_s,nil] :old_version Alternative installation script name
+  #    that absorbs the existing objects into the extension, instead of creating new objects
+  def enable_extension(extension_name, options = {})
+    options[:if_not_exists] = true
+    create_extension(extension_name, options).tap { reload_type_map }
+  end
+
   # Execute SQL to remove a postgresql extension module from the current database.
   #
   # @param [#to_s] extension_name Name of the extension module to unload

--- a/spec/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods_spec.rb
+++ b/spec/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods do
-  class PostgreSQLAdapter
+  class FakePostgreSQLAdapter
     include ::PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   end
 
-  let(:adapter_stub) { PostgreSQLAdapter.new }
+  let(:adapter_stub) { FakePostgreSQLAdapter.new }
 
   it ".supports_extensions?" do
     expect(adapter_stub.supports_extensions?).to be true
@@ -15,6 +15,13 @@ describe PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods do
     expect(adapter_stub).to receive(:execute).with(/CREATE EXTENSION(.+)\"someextension\"(.?)/)
 
     adapter_stub.create_extension("someextension", {})
+  end
+
+  it ".enable_extension" do
+    expect(adapter_stub).to receive(:execute).with(/CREATE EXTENSION(.+)\"someextension\"(.?)/)
+    allow_any_instance_of(FakePostgreSQLAdapter).to receive(:reload_type_map)
+
+    adapter_stub.enable_extension("someextension", {})
   end
 
   describe ".drop_extension" do


### PR DESCRIPTION
Per HornsAndHooves/pg_saurus#6

Unless I'm mistaken, any use of `enable_extension` in a migration would be dumped as a `create_extension` call.