### PR TITLE
14978 accommodate schema-qualified table names

### DIFF
--- a/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
@@ -5,7 +5,7 @@ module ActiveRecord # :nodoc:
     #   * indexes
     class PostgreSQLAdapter
       # Regex to find columns used in index statements
-      INDEX_COLUMN_EXPRESSION = /ON \w+(?: USING \w+ )?\((.+)\)/
+      INDEX_COLUMN_EXPRESSION = /ON [\w\.]+(?: USING \w+ )?\((.+)\)/
       # Regex to find where clause in index statements
       INDEX_WHERE_EXPRESSION = /WHERE (.+)$/
 

--- a/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
@@ -116,7 +116,7 @@ module ActiveRecord # :nodoc:
       # this is an expression index) then it will try to return the functions
       # that represent each column.
       #
-      # @param [String] table_name the name of the table
+      # @param [String] table_name the name of the table, possibly schema-qualified
       # @param [Hash] index index attributes
       # @return [Array]
       def find_column_names(table_name, index)

--- a/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
@@ -7,7 +7,7 @@ module ActiveRecord # :nodoc:
       # Regex to find columns used in index statements
       INDEX_COLUMN_EXPRESSION = /ON \w+(?: USING \w+ )?\((.+)\)/
       # Regex to find where clause in index statements
-      INDEX_WHERE_EXPRESION = /WHERE (.+)$/
+      INDEX_WHERE_EXPRESSION = /WHERE (.+)$/
 
       # Returns the list of all tables in the schema search path or a specified schema.
       #
@@ -122,7 +122,7 @@ module ActiveRecord # :nodoc:
         column_names = columns.values_at(*index[:keys]).compact
 
         if column_names.empty?
-          definition = index[:definition].sub(INDEX_WHERE_EXPRESION, '')
+          definition = index[:definition].sub(INDEX_WHERE_EXPRESSION, '')
           if column_expression = definition.match(INDEX_COLUMN_EXPRESSION)[1]
             column_names = split_expression(column_expression).map do |functional_name|
               remove_type(functional_name)
@@ -165,7 +165,7 @@ module ActiveRecord # :nodoc:
       # @param [Hash] index index attributes
       # @return [String] where statement
       def find_where_statement(index)
-        index[:definition].scan(INDEX_WHERE_EXPRESION).flatten[0]
+        index[:definition].scan(INDEX_WHERE_EXPRESSION).flatten[0]
       end
 
       # Find length of index

--- a/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
@@ -99,14 +99,22 @@ module ActiveRecord # :nodoc:
             where   = find_where_statement(index)
             lengths = find_lengths(index)
 
-            PgSaurus::ConnectionAdapters::IndexDefinition.new(table_name, index[:name], index[:unique], column_names, lengths, where, index[:access_method])
+            PgSaurus::ConnectionAdapters::IndexDefinition.new(
+              table_name,
+              index[:name],
+              index[:unique],
+              column_names,
+              lengths,
+              where,
+              index[:access_method]
+            )
           end
         end.compact
       end
 
-      # Find column names from index attributes. If the columns are virtual (ie
+      # Find column names from index attributes. If the columns are virtual (i.e.
       # this is an expression index) then it will try to return the functions
-      # that represent each column
+      # that represent each column.
       #
       # @param [String] table_name the name of the table
       # @param [Hash] index index attributes

--- a/spec/indexes_spec.rb
+++ b/spec/indexes_spec.rb
@@ -44,6 +44,14 @@ describe 'Indexes' do
       ActiveRecord::Migration.add_index(:pets, ['upper(name)', 'lower(color)'], opts)
       PgSaurus::Explorer.index_exists?(:pets, ['upper(name)', 'lower(color)'], opts).should be true
     end
+
+    it "should allow compound functional indexes for schema-qualified table names" do
+      opts = { name: 'idx_demography_citizens_on_lower_last_name__lower_first_name' }
+      args = [ "demography.citizens", ["lower(last_name)", "lower(first_name)"], opts ]
+
+      ActiveRecord::Migration.add_index(*args)
+      expect(PgSaurus::Explorer.index_exists?(*args)).to be_truthy
+    end
   end
 
   describe '#remove_index' do


### PR DESCRIPTION
Task 14978

`#find_column_names` would fail for new compound functional indexes for schema-qualified table names.
