### PR TITLE
19615 support operator strings in functional indexes

### DIFF
--- a/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
@@ -5,8 +5,8 @@ module ActiveRecord
       # function call
       FUNCTIONAL_INDEX_REGEXP = /(\w+)\(((?:'.+'(?:::\w+)?, *)*)(\w+)\)/
 
-      # Regexp used to find the operator name
-      OPERATOR_REGEXP = /(.+)\s(\w+)$/
+      # Regexp used to find the operator name (or operator string, e.g. "DESC NULLS LAST"):
+      OPERATOR_REGEXP = /(.+?)\s([\w\s]+)$/
 
       # Redefine original add_index method to handle :concurrently option.
       #

--- a/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
@@ -159,7 +159,7 @@ module ActiveRecord
                         column_name
                       end
 
-        result_name += "_" + operator_name if operator_name
+        result_name += "_" + operator_name.parameterize.underscore if operator_name
 
         result_name
       end

--- a/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module ConnectionAdapters # :nodoc:
     module SchemaStatements # :nodoc:
       # Regexp used to find the function name and function argument of a
-      # function call
+      # function call:
       FUNCTIONAL_INDEX_REGEXP = /(\w+)\(((?:'.+'(?:::\w+)?, *)*)(\w+)\)/
 
       # Regexp used to find the operator name (or operator string, e.g. "DESC NULLS LAST"):

--- a/spec/active_record/schema_dumper_spec.rb
+++ b/spec/active_record/schema_dumper_spec.rb
@@ -88,11 +88,11 @@ describe ActiveRecord::SchemaDumper do
         @dump.should =~ /add_index "pets", \["upper\(color\)"\].*:where => "\(name IS NULL\)"/
       end
 
-      it 'dumps indexes with non default access method' do
+      it 'dumps indexes with non-default access method' do
         @dump.should =~ Regexp.new(Regexp.quote('add_index "pets", ["user_id"], :name => "index_pets_on_user_id_gist", :using => "gist"'))
       end
 
-      it 'dumps indexes with non default access method and multiple args' do
+      it 'dumps indexes with non-default access method and multiple args' do
         @dump.should =~ Regexp.new(Regexp.quote(
           'add_index "pets", ["to_tsvector(\'english\'::regconfig, name)"], :name => "index_pets_on_to_tsvector_name_gist", :using => "gist"'
         ))
@@ -100,6 +100,10 @@ describe ActiveRecord::SchemaDumper do
 
       it "dumps indexes with operator name" do
         @dump.should =~ /add_index "books", \["title varchar_pattern_ops"\]/
+      end
+
+      it "dumps functional indexes with longer operator strings" do
+        @dump.should =~ /add_index "pets", \["lower\(name\) DESC NULLS LAST"\]/
       end
     end
 

--- a/spec/dummy/db/migrate/20190320025645_add_functional_index_with_longer_operator_string.rb
+++ b/spec/dummy/db/migrate/20190320025645_add_functional_index_with_longer_operator_string.rb
@@ -1,0 +1,5 @@
+class AddFunctionalIndexWithLongerOperatorString < ActiveRecord::Migration
+  def change
+    add_index :pets, ["lower(name) DESC NULLS LAST"]
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190213151821) do
+ActiveRecord::Schema.define(version: 20190320025645) do
 
   create_schema "demography"
   create_schema "later"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20190213151821) do
   add_index "pets", ["breed_id"], :name => "index_pets_on_breed_id"
   add_index "pets", ["color"], :name => "index_pets_on_color"
   add_index "pets", ["country_id"], :name => "index_pets_on_country_id"
+  add_index "pets", ["lower(name) DESC NULLS LAST"], :name => "index_pets_on_lower_name_desc_nulls_last"
   add_index "pets", ["lower(name)"], :name => "index_pets_on_lower_name"
   add_index "pets", ["to_tsvector('english'::regconfig, name)"], :name => "index_pets_on_to_tsvector_name_gist", :using => "gist"
   add_index "pets", ["upper(color)"], :name => "index_pets_on_upper_color", :where => "(name IS NULL)"

--- a/spec/indexes_spec.rb
+++ b/spec/indexes_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'Indexes' do
   describe '#add_index' do
-    it 'should be built with the :where option' do
+    it 'is built with the :where option' do
       index_options = {:where => "active"}
 
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
@@ -10,19 +10,19 @@ describe 'Indexes' do
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
-    it 'should allow indexes with expressions using functions' do
+    it 'allows indexes with expressions using functions' do
       ActiveRecord::Migration.add_index(:pets, ["lower(name)", "lower(color)"])
 
       PgSaurus::Explorer.index_exists?(:pets, ["lower(name)", "lower(color)"] ).should be true
     end
 
-    it 'should allow indexes with expressions using functions with multiple arguments' do
+    it 'allows indexes with expressions using functions with multiple arguments' do
       ActiveRecord::Migration.add_index(:pets, "to_tsvector('english', name)", :using => 'gin')
 
       PgSaurus::Explorer.index_exists?(:pets, "gin(to_tsvector('english', name))" ).should be true
     end
 
-    it 'should allow indexes with expressions using functions with multiple arguments as dumped' do
+    it 'allows indexes with expressions using functions with multiple arguments as dumped' do
       ActiveRecord::Migration.add_index(:pets,
                                         "to_tsvector('english'::regconfig, name)",
                                         :using => 'gin')
@@ -31,21 +31,21 @@ describe 'Indexes' do
     end
 
     # TODO support this canonical example
-    it 'should allow indexes with advanced expressions' do
+    it 'allows indexes with advanced expressions' do
       pending "Not sophisticated enough for this yet"
       ActiveRecord::Migration.add_index(:pets, ["(color || ' ' || name)"])
 
       PgSaurus::Explorer.index_exists?(:pets, ["(color || ' ' || name)"] ).should be true
     end
 
-    it "should allow partial indexes with expressions" do
+    it "allows partial indexes with expressions" do
       opts = {:where => 'color IS NULL'}
 
       ActiveRecord::Migration.add_index(:pets, ['upper(name)', 'lower(color)'], opts)
       PgSaurus::Explorer.index_exists?(:pets, ['upper(name)', 'lower(color)'], opts).should be true
     end
 
-    it "should allow compound functional indexes for schema-qualified table names" do
+    it "allows compound functional indexes for schema-qualified table names" do
       opts = { name: 'idx_demography_citizens_on_lower_last_name__lower_first_name' }
       args = [ "demography.citizens", ["lower(last_name)", "lower(first_name)"], opts ]
 
@@ -55,14 +55,14 @@ describe 'Indexes' do
   end
 
   describe '#remove_index' do
-    it 'should remove indexes with expressions using functions' do
+    it 'removes indexes with expressions using functions' do
       ActiveRecord::Migration.add_index(:pets, ["lower(name)", "lower(color)"])
       ActiveRecord::Migration.remove_index(:pets, ["lower(name)", "lower(color)"])
 
       PgSaurus::Explorer.index_exists?(:pets, ["lower(name)", "lower(color)"] ).should be false
     end
 
-    it 'should remove indexes built with the :where option' do
+    it 'removes indexes built with the :where option' do
 
       index_options = {:where => "active"}
 
@@ -74,19 +74,19 @@ describe 'Indexes' do
   end
 
   describe '#index_exists' do
-    it 'should be true for simple options' do
+    it 'is true for simple options' do
       PgSaurus::Explorer.index_exists?('pets', :color).should be true
     end
 
-    it 'should support table name as a symbol' do
+    it 'supports table name as a symbol' do
       PgSaurus::Explorer.index_exists?(:pets, :color).should be true
     end
 
-    it 'should be true for simple options on a schema table' do
+    it 'is true for simple options on a schema table' do
       PgSaurus::Explorer.index_exists?('demography.cities', :country_id).should be true
     end
 
-    it 'should be true for a valid set of options' do
+    it 'is true for a valid set of options' do
       index_options = {:unique => true, :where => 'active'}
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id, :user_id],
@@ -94,7 +94,7 @@ describe 'Indexes' do
                                      ).should be true
     end
 
-    it 'should be true for a valid set of options including name' do
+    it 'is true for a valid set of options including name' do
       index_options = { :unique => true,
                         :where  => 'active',
                         :name   => 'index_demography_citizens_on_country_id_and_user_id' }
@@ -104,7 +104,7 @@ describe 'Indexes' do
                                      ).should be true
     end
 
-    it 'should be false for a subset of valid options' do
+    it 'is false for a subset of valid options' do
       index_options = {:where => 'active'}
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id, :user_id],
@@ -112,7 +112,7 @@ describe 'Indexes' do
                                      ).should be false
     end
 
-    it 'should be false for invalid options' do
+    it 'is false for invalid options' do
       index_options = {:where => 'active'}
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id],
@@ -120,37 +120,37 @@ describe 'Indexes' do
                                      ).should be false
     end
 
-    it 'should be true for a :where clause that includes boolean comparison' do
+    it 'is true for a :where clause that includes boolean comparison' do
       index_options = {:where => 'active'}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
-    it 'should be true for a :where clause that includes text comparison' do
+    it 'is true for a :where clause that includes text comparison' do
       index_options = {:where => "color = 'black'"}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
-    it 'should be true for a :where clause that includes NULL comparison' do
+    it 'is true for a :where clause that includes NULL comparison' do
       index_options = {:where => 'color IS NULL'}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
-    it 'should be true for a :where clause that includes integer comparison' do
+    it 'is true for a :where clause that includes integer comparison' do
       index_options = {:where => 'id = 4'}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
-    it 'should be true for a compound :where clause' do
+    it 'is true for a compound :where clause' do
       index_options = {:where => "id = 4 and color = 'black' and active"}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
-    it 'should be true for concurrently created index' do
+    it 'is true for concurrently created index' do
       index_options = {:concurrently => true}
       PgSaurus::Explorer.index_exists?(:users, :email, index_options).should be true
     end

--- a/spec/lib/core_ext/connection_adapters/abstract/schema_statements_spec.rb
+++ b/spec/lib/core_ext/connection_adapters/abstract/schema_statements_spec.rb
@@ -36,6 +36,24 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
       end
     end
 
+    context "for functional index with longer operator string" do
+      let(:expected_query) do
+        'CREATE  INDEX "index_users_on_lower_first_name_desc_nulls_last" ' \
+        'ON "users" (lower("first_name") DESC NULLS LAST)'
+      end
+
+      it 'creates functional index for column with longer operator string' do
+        ActiveRecord::Migration.clear_queue
+
+        expect(ActiveRecord::Base.connection).to receive(:execute) do |query|
+          query.should == expected_query
+        end
+
+        ActiveRecord::Migration.add_index :users, "lower(first_name) DESC NULLS LAST"
+        ActiveRecord::Migration.process_postponed_queries
+      end
+    end
+
     it 'raises index exists error' do
       expect(ActiveRecord::Base.connection).
         to receive(:index_exists?).once.and_return(true)


### PR DESCRIPTION
Task 19615

Functional indexes with an operator name work. But if there is more than one word in a longer operator string (e.g. "DESC NULLS LAST") creating and dumping the index fails.

These changes fix that.

ref: https://www.postgresql.org/docs/9.6/indexes-ordering.html