### PR TITLE
Add simple rubocop file enforcing hash syntax style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+
+# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Style/HashSyntax:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,8 @@ group :development do
 
   # code metrics:
   gem 'yard'
-  gem 'metric_fu', :require => false
-  gem 'jeweler'  , :require => false
+  gem 'metric_fu', require: false
+  gem 'jeweler'  , require: false
 
 
   unless ENV["RM_INFO"]
@@ -39,9 +39,10 @@ end
 group :development, :test do
   gem "pry"
   gem "pry-byebug"
+  gem "rubocop"
 end
 
 group :test do
-  gem 'simplecov'          , :require => false
-  gem 'simplecov-rcov-text', :require => false
+  gem 'simplecov'          , require: false
+  gem 'simplecov-rcov-text', require: false
 end

--- a/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/lib/core_ext/active_record/connection_adapters/abstract/schema_statements.rb
@@ -15,8 +15,8 @@ module ActiveRecord
         # an Array of Symbols.
         #
         # ====== Creating a partial index
-        #  add_index(:accounts, [:branch_id, :party_id], :using => 'BTree'
-        #   :unique => true, :concurrently => true, :where => 'active')
+        #  add_index(:accounts, [:branch_id, :party_id], using: 'BTree'
+        #   unique: true, concurrently: true, where: 'active')
         # generates
         #  CREATE UNIQUE INDEX CONCURRENTLY
         #   index_accounts_on_branch_id_and_party_id
@@ -76,15 +76,15 @@ module ActiveRecord
         #
         # === Examples
         #  # Check that a partial index exists
-        #  index_exists?(:suppliers, :company_id, :where => 'active')
+        #  index_exists?(:suppliers, :company_id, where: 'active')
         #
         #  # GIVEN: 'index_suppliers_on_company_id' UNIQUE, btree (company_id) WHERE active
-        #  index_exists?(:suppliers, :company_id, :unique => true, :where => 'active') => true
-        #  index_exists?(:suppliers, :company_id, :unique => true) => false
+        #  index_exists?(:suppliers, :company_id, unique: true, where: 'active') => true
+        #  index_exists?(:suppliers, :company_id, unique: true) => false
         #
         def index_exists?(table_name, column_name, options = {})
           column_names = Array.wrap(column_name)
-          index_name = options.key?(:name) ? options[:name].to_s : index_name(table_name, :column => column_names)
+          index_name = options.key?(:name) ? options[:name].to_s : index_name(table_name, column: column_names)
 
           # Always compare the index name
           default_comparator = lambda { |index| index.name == index_name }
@@ -133,7 +133,7 @@ module ActiveRecord
               raise ArgumentError, "You must specify the index name"
             end
           else
-            index_name(table_name, :column => options)
+            index_name(table_name, column: options)
           end
         end
 

--- a/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/core_ext/active_record/connection_adapters/postgresql_adapter.rb
@@ -85,13 +85,13 @@ module ActiveRecord # :nodoc:
 
         result.map do |row|
           index = {
-            :name          => row[0],
-            :unique        => row[1] == 't',
-            :keys          => row[2].split(" "),
-            :definition    => row[3],
-            :id            => row[4],
-            :access_method => row[5], 
-            :operators     => row[6].split(" ")
+            name: row[0],
+            unique: row[1] == 't',
+            keys: row[2].split(" "),
+            definition: row[3],
+            id: row[4],
+            access_method: row[5], 
+            operators: row[6].split(" ")
           }
 
           column_names = find_column_names(table_name, index)

--- a/lib/core_ext/active_record/schema_dumper.rb
+++ b/lib/core_ext/active_record/schema_dumper.rb
@@ -26,20 +26,20 @@ module ActiveRecord #:nodoc:
           statement_parts = [
             ('add_index ' + index.table.inspect),
             is_json_index ? "\"#{columns.first}\"" : columns.inspect,
-            (':name => ' + index.name.inspect),
+            ('name: ' + index.name.inspect),
           ]
-          statement_parts << ':unique => true' if index.unique
+          statement_parts << 'unique: true' if index.unique
 
           index_lengths = (index.lengths || []).compact
-          statement_parts << (':length => ' + Hash[index.columns.zip(index.lengths)].inspect) unless index_lengths.empty?
+          statement_parts << ('length: ' + Hash[index.columns.zip(index.lengths)].inspect) unless index_lengths.empty?
 
           # Patch
           #  Append :where clause if a partial index
-          statement_parts << (':where => ' + index.where.inspect) if index.where
+          statement_parts << ('where: ' + index.where.inspect) if index.where
 
-          statement_parts << (':using => ' + index.access_method.inspect) unless index.access_method.downcase == 'btree'
+          statement_parts << ('using: ' + index.access_method.inspect) unless index.access_method.downcase == 'btree'
 
-          statement_parts << ':skip_column_quoting => true' if is_json_index
+          statement_parts << 'skip_column_quoting: true' if is_json_index
 
           '  ' + statement_parts.join(', ')
         end

--- a/lib/pg_saurus/connection_adapters/abstract_adapter/comment_methods.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter/comment_methods.rb
@@ -27,8 +27,8 @@ module PgSaurus::ConnectionAdapters::AbstractAdapter::CommentMethods
   #
   # ===== Example
   # ====== Setting comments on the columns of the phone_numbers table
-  #  set_column_comments :phone_numbers, :npa => 'Numbering Plan Area Code - Allowed ranges: [2-9] for first digit, [0-9] for second and third digit.',
-  #                                      :nxx => 'Central Office Number'
+  #  set_column_comments :phone_numbers, npa: 'Numbering Plan Area Code - Allowed ranges: [2-9] for first digit, [0-9] for second and third digit.',
+  #                                      nxx: 'Central Office Number'
   def set_column_comments(table_name, comments)
 
   end

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
@@ -3,16 +3,16 @@
 module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   # Default options for {#create_extension} method.
   CREATE_EXTENSION_DEFAULTS = {
-      :if_not_exists => true,
-      :schema_name   => nil,
-      :version       => nil,
-      :old_version   => nil
+      if_not_exists: true,
+      schema_name: nil,
+      version: nil,
+      old_version: nil
   }
 
   # Default options for {#drop_extension} method.
   DROP_EXTENSION_DEFAULTS = {
-      :if_exists => true,
-      :mode      => :restrict
+      if_exists: true,
+      mode: :restrict
   }
 
   # The modes which determine postgresql behavior on DROP EXTENSION operation.
@@ -20,8 +20,8 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   # *:restrict* refuse to drop the extension if any objects depend on it
   # *:cascade* automatically drop objects that depend on the extension
   AVAILABLE_DROP_MODES = {
-      :restrict => 'RESTRICT',
-      :cascade  => 'CASCADE'
+      restrict: 'RESTRICT',
+      cascade: 'CASCADE'
   }
 
   # @return [Boolean] if adapter supports postgresql extension manipulation
@@ -106,7 +106,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   # ===Example
   #
   #   extension # => {
-  #     "fuzzystrmatch" => {:schema_name => "public", :version => "1.0" }
+  #     "fuzzystrmatch" => {schema_name: "public", version: "1.0" }
   #   }
   #
   # @return [Hash{String => Hash{Symbol => String}}] A list of loaded extensions with their options
@@ -127,8 +127,8 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
       [
           row['ext_name'],
           {
-              :schema_name => row['schema_name'],
-              :version => row['ext_version']
+              schema_name: row['schema_name'],
+              version: row['ext_version']
           }
       ]
     end

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/foreign_key_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/foreign_key_methods.rb
@@ -22,7 +22,7 @@ module PgSaurus # :nodoc:
     end
 
     # See activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
-    # Creates index on the FK column by default. Pass in the option :exclude_index => true
+    # Creates index on the FK column by default. Pass in the option exclude_index: true
     # to disable this.
     def add_foreign_key(from_table, to_table, options = {})
       exclude_index = (options.has_key?(:exclude_index) ? options.delete(:exclude_index) : false)
@@ -31,7 +31,7 @@ module PgSaurus # :nodoc:
       if index_exists?(from_table, column) && !exclude_index
         raise PgSaurus::IndexExistsError,
               "The index, #{index_name(from_table, column)}, already exists." \
-          "  Use :exclude_index => true when adding the foreign key."
+          "  Use exclude_index: true when adding the foreign key."
       end
 
       super from_table, to_table, options

--- a/lib/pg_saurus/connection_adapters/table/comment_methods.rb
+++ b/lib/pg_saurus/connection_adapters/table/comment_methods.rb
@@ -32,8 +32,8 @@ module PgSaurus::ConnectionAdapters::Table::CommentMethods
   #
   # ===== Example
   # ====== Setting comments on the columns of the phone_numbers table
-  #  t.set_column_comments :npa => 'Numbering Plan Area Code - Allowed ranges: [2-9] for first digit, [0-9] for second and third digit.',
-  #                        :nxx => 'Central Office Number'
+  #  t.set_column_comments npa: 'Numbering Plan Area Code - Allowed ranges: [2-9] for first digit, [0-9] for second and third digit.',
+  #                        nxx: 'Central Office Number'
   def set_column_comments(comments)
     @base.set_column_comments(@name, comments)
   end

--- a/lib/pg_saurus/create_index_concurrently.rb
+++ b/lib/pg_saurus/create_index_concurrently.rb
@@ -24,7 +24,7 @@
 #
 #   class AddIndexToNameForUsers < ActiveRecord::Migration
 #     def change
-#       add_index :users, :name, :concurrently => true
+#       add_index :users, :name, concurrently: true
 #     end
 #   end
 #
@@ -32,7 +32,7 @@
 #
 #   class AddForeignKeyToRoleIdForUsers < ActiveRecord::Migration
 #     def change
-#       add_foreign_key :users, :roles, :concurrent_index => true
+#       add_foreign_key :users, :roles, concurrent_index: true
 #     end
 #   end
 #
@@ -133,7 +133,7 @@ module PgSaurus::CreateIndexConcurrently
   module MigrationProxy
     # :nodoc:
     def self.included(klass)
-      klass.delegate :process_postponed_queries, :to => :migration
+      klass.delegate :process_postponed_queries, to: :migration
     end
   end
 

--- a/lib/pg_saurus/schema_dumper/extension_methods.rb
+++ b/lib/pg_saurus/schema_dumper/extension_methods.rb
@@ -15,8 +15,8 @@ module PgSaurus::SchemaDumper::ExtensionMethods
     extensions = @connection.pg_extensions
     commands   = extensions.map do |extension_name, options|
       result = [%Q|create_extension "#{extension_name}"|]
-      result << %Q|:schema_name => "#{options[:schema_name]}"| unless options[:schema_name] == 'public'
-      result << %Q|:version => "#{options[:version]}"|
+      result << %Q|schema_name: "#{options[:schema_name]}"| unless options[:schema_name] == 'public'
+      result << %Q|version: "#{options[:version]}"|
       result.join(', ')
     end
 

--- a/lib/pg_saurus/schema_dumper/foreign_key_methods.rb
+++ b/lib/pg_saurus/schema_dumper/foreign_key_methods.rb
@@ -36,8 +36,8 @@ module PgSaurus::SchemaDumper::ForeignKeyMethods
         # Always exclude the index
         #  If an index was created in a migration, it will get dumped to the schema
         #  separately from the foreign key.  This will raise an exception if
-        #  add_foreign_key is run without :exclude_index => true.
-        parts << ":exclude_index => true"
+        #  add_foreign_key is run without exclude_index: true.
+        parts << "exclude_index: true"
 
         "  #{parts.join(', ')}"
       end

--- a/spec/active_record/schema_dumper_spec.rb
+++ b/spec/active_record/schema_dumper_spec.rb
@@ -48,8 +48,8 @@ describe ActiveRecord::SchemaDumper do
 
     context "Extensions" do
       it 'dumps loaded extension modules' do
-        @dump.should =~ /create_extension "fuzzystrmatch", :version => "\d+\.\d+"/
-        @dump.should =~ /create_extension "btree_gist", :schema_name => "demography", :version => "\d+\.\d+"/
+        @dump.should =~ /create_extension "fuzzystrmatch", version: "\d+\.\d+"/
+        @dump.should =~ /create_extension "btree_gist", schema_name: "demography", version: "\d+\.\d+"/
       end
     end
 
@@ -72,7 +72,7 @@ describe ActiveRecord::SchemaDumper do
         # foreign key :exclude_index
         @dump.should_not =~ /add_index "demography\.citizens", \["user_id"\]/
         # partial index
-        @dump.should =~ /add_index "demography.citizens", \["country_id", "user_id"\].*:where => "active"/
+        @dump.should =~ /add_index "demography.citizens", \["country_id", "user_id"\].*where: "active"/
       end
 
       # This index is added via add_foreign_key
@@ -85,16 +85,16 @@ describe ActiveRecord::SchemaDumper do
       end
 
       it 'dumps partial functional indexes' do
-        @dump.should =~ /add_index "pets", \["upper\(color\)"\].*:where => "\(name IS NULL\)"/
+        @dump.should =~ /add_index "pets", \["upper\(color\)"\].*where: "\(name IS NULL\)"/
       end
 
       it 'dumps indexes with non-default access method' do
-        @dump.should =~ Regexp.new(Regexp.quote('add_index "pets", ["user_id"], :name => "index_pets_on_user_id_gist", :using => "gist"'))
+        @dump.should =~ Regexp.new(Regexp.quote('add_index "pets", ["user_id"], name: "index_pets_on_user_id_gist", using: "gist"'))
       end
 
       it 'dumps indexes with non-default access method and multiple args' do
         @dump.should =~ Regexp.new(Regexp.quote(
-          'add_index "pets", ["to_tsvector(\'english\'::regconfig, name)"], :name => "index_pets_on_to_tsvector_name_gist", :using => "gist"'
+          'add_index "pets", ["to_tsvector(\'english\'::regconfig, name)"], name: "index_pets_on_to_tsvector_name_gist", using: "gist"'
         ))
       end
 

--- a/spec/dummy/app/models/demography/country.rb
+++ b/spec/dummy/app/models/demography/country.rb
@@ -1,3 +1,3 @@
 class Demography::Country < ActiveRecord::Base
-  has_many :citizens, :class_name => 'Demography::Citizen'
+  has_many :citizens, class_name: 'Demography::Citizen'
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,3 +1,3 @@
 class User < ActiveRecord::Base
-  has_one :citizen, :class_name => 'Demography::Citizen'
+  has_one :citizen, class_name: 'Demography::Citizen'
 end

--- a/spec/dummy/config/initializers/session_store.rb
+++ b/spec/dummy/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Dummy::Application.config.session_store :cookie_store, :key => '_dummy_session'
+Dummy::Application.config.session_store :cookie_store, key: '_dummy_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/spec/dummy/config/initializers/wrap_parameters.rb
+++ b/spec/dummy/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters :format => [:json]
+  wrap_parameters format: [:json]
 end
 
 # Disable root element in JSON by default.

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,8 +7,8 @@ Dummy::Application.routes.draw do
   # Keep in mind you can assign values other than :controller and :action
 
   # Sample of named route:
-  #   match 'products/:id/purchase' => 'catalog#purchase', :as => :purchase
-  # This route can be invoked with purchase_url(:id => product.id)
+  #   match 'products/:id/purchase' => 'catalog#purchase', as: :purchase
+  # This route can be invoked with purchase_url(id: product.id)
 
   # Sample resource route (maps HTTP verbs to controller actions automatically):
   #   resources :products
@@ -35,7 +35,7 @@ Dummy::Application.routes.draw do
   #   resources :products do
   #     resources :comments
   #     resources :sales do
-  #       get 'recent', :on => :collection
+  #       get 'recent', on: :collection
   #     end
   #   end
 
@@ -48,7 +48,7 @@ Dummy::Application.routes.draw do
 
   # You can have the root of your site routed with "root"
   # just remember to delete public/index.html.
-  # root :to => 'welcome#index'
+  # root to: 'welcome#index'
 
   # See how all your routes lay out with "rake routes"
 

--- a/spec/dummy/db/migrate/20120105112744_create_pets.rb
+++ b/spec/dummy/db/migrate/20120105112744_create_pets.rb
@@ -8,7 +8,7 @@ class CreatePets < ActiveRecord::Migration
       t.integer :citizen_id
       t.integer :breed_id
       t.integer :owner_id
-      t.boolean :active, :default => true
+      t.boolean :active, default: true
     end
 
     add_index(:pets, :color)

--- a/spec/dummy/db/migrate/20120106163544_create_users.rb
+++ b/spec/dummy/db/migrate/20120106163544_create_users.rb
@@ -15,7 +15,7 @@ class CreateUsers < ActiveRecord::Migration
     set_column_comment :users, :name, "User name"
 
     set_column_comments :users,
-      :email        => "Email address",
-      :phone_number => "Phone number"
+      email: "Email address",
+      phone_number: "Phone number"
   end
 end

--- a/spec/dummy/db/migrate/20120106163810_create_demography_countries.rb
+++ b/spec/dummy/db/migrate/20120106163810_create_demography_countries.rb
@@ -10,7 +10,7 @@ class CreateDemographyCountries < ActiveRecord::Migration
     set_table_comment 'demography.countries', "Countries"
 
     set_column_comments 'demography.countries',
-      :name => "Country name",
-      :continent => "Continent"
+      name: "Country name",
+      continent: "Continent"
   end
 end

--- a/spec/dummy/db/migrate/20120106163820_create_demography_citizens.rb
+++ b/spec/dummy/db/migrate/20120106163820_create_demography_citizens.rb
@@ -16,9 +16,9 @@ class CreateDemographyCitizens < ActiveRecord::Migration
     set_column_comment 'demography.citizens', :country_id, 'Country key'
 
     set_column_comments 'demography.citizens',
-      :first_name => "First name",
-      :last_name  => "Last name",
-      :birthday   => "Birthday",
-      :bio        => "Biography"
+      first_name: "First name",
+      last_name: "Last name",
+      birthday: "Birthday",
+      bio: "Biography"
   end
 end

--- a/spec/dummy/db/migrate/20120207150844_add_foreign_keys.rb
+++ b/spec/dummy/db/migrate/20120207150844_add_foreign_keys.rb
@@ -8,7 +8,7 @@ class AddForeignKeys < ActiveRecord::Migration
     add_foreign_key 'demography.citizens', 'demography.countries' # This foreign key is removed in RemoveForeignKeys migration
 
     # Add foreign key without an index
-    add_foreign_key 'demography.citizens', 'users', :exclude_index => true
+    add_foreign_key 'demography.citizens', 'users', exclude_index: true
 
   end
 end

--- a/spec/dummy/db/migrate/20120207163652_remove_foreign_keys.rb
+++ b/spec/dummy/db/migrate/20120207163652_remove_foreign_keys.rb
@@ -3,8 +3,8 @@ class RemoveForeignKeys < ActiveRecord::Migration
     remove_foreign_key 'demography.citizens', column: :country_id, remove_index: true
     remove_foreign_key 'pets', 'demography.countries'
     #remove_foreign_key 'pets', 'owners'
-    remove_foreign_key 'pets', :column => "owner_id", remove_index: true
-    remove_foreign_key 'pets', :column => "breed_id"
+    remove_foreign_key 'pets', column: "owner_id", remove_index: true
+    remove_foreign_key 'pets', column: "breed_id"
   end
 
   def down

--- a/spec/dummy/db/migrate/20120208114020_remove_some_comments_on_citizens.rb
+++ b/spec/dummy/db/migrate/20120208114020_remove_some_comments_on_citizens.rb
@@ -5,7 +5,7 @@ class RemoveSomeCommentsOnCitizens < ActiveRecord::Migration
 
   def down
     set_column_comments 'demography.citizens',
-      :birthday   => "Birthday",
-      :bio        => "Biography"
+      birthday: "Birthday",
+      bio: "Biography"
   end
 end

--- a/spec/dummy/db/migrate/20120224204546_add_demography_citizens_active_column.rb
+++ b/spec/dummy/db/migrate/20120224204546_add_demography_citizens_active_column.rb
@@ -1,7 +1,7 @@
 class AddDemographyCitizensActiveColumn < ActiveRecord::Migration
   def change
-    add_column 'demography.citizens', :active, :boolean, :null => false, :default => false
+    add_column 'demography.citizens', :active, :boolean, null: false, default: false
 
-    add_index 'demography.citizens', [:country_id, :user_id], :unique => true, :where => 'active'
+    add_index 'demography.citizens', [:country_id, :user_id], unique: true, where: 'active'
   end
 end

--- a/spec/dummy/db/migrate/20120301153650_demography_population_statistics.rb
+++ b/spec/dummy/db/migrate/20120301153650_demography_population_statistics.rb
@@ -1,6 +1,6 @@
 class DemographyPopulationStatistics < ActiveRecord::Migration
   def change
-    create_table "population_statistics", :schema => "demography" do |t|
+    create_table "population_statistics", schema: "demography" do |t|
       t.integer :year
       t.integer :population
     end

--- a/spec/dummy/db/migrate/20120301171826_remove_demography_nationalities.rb
+++ b/spec/dummy/db/migrate/20120301171826_remove_demography_nationalities.rb
@@ -1,5 +1,5 @@
 class RemoveDemographyNationalities < ActiveRecord::Migration
   def change
-    drop_table 'nationalities', :schema => 'demography'
+    drop_table 'nationalities', schema: 'demography'
   end
 end

--- a/spec/dummy/db/migrate/20120517211922_add_partial_functional_index.rb
+++ b/spec/dummy/db/migrate/20120517211922_add_partial_functional_index.rb
@@ -1,5 +1,5 @@
 class AddPartialFunctionalIndex < ActiveRecord::Migration
   def change
-    add_index :pets, ["upper(color)"], :where => 'name IS NULL'
+    add_index :pets, ["upper(color)"], where: 'name IS NULL'
   end
 end

--- a/spec/dummy/db/migrate/20120904113806_add_concurrently_index_to_users_on_email.rb
+++ b/spec/dummy/db/migrate/20120904113806_add_concurrently_index_to_users_on_email.rb
@@ -1,5 +1,5 @@
 class AddConcurrentlyIndexToUsersOnEmail < ActiveRecord::Migration
   def change
-    add_index :users, :email, :concurrently => true
+    add_index :users, :email, concurrently: true
   end
 end

--- a/spec/dummy/db/migrate/20120904114121_add_concurrently_index_with_foreign_key.rb
+++ b/spec/dummy/db/migrate/20120904114121_add_concurrently_index_with_foreign_key.rb
@@ -1,5 +1,5 @@
 class AddConcurrentlyIndexWithForeignKey < ActiveRecord::Migration
   def change
-    add_foreign_key :pets, :users, :exclude_index => true#, :concurrent_index => true
+    add_foreign_key :pets, :users, exclude_index: true#, concurrent_index: true
   end
 end

--- a/spec/dummy/db/migrate/20121009170904_create_extension.rb
+++ b/spec/dummy/db/migrate/20121009170904_create_extension.rb
@@ -1,7 +1,7 @@
 class CreateExtension < ActiveRecord::Migration
   def change
     create_extension "fuzzystrmatch"
-    drop_extension "fuzzystrmatch", :mode => :cascade
+    drop_extension "fuzzystrmatch", mode: :cascade
     create_extension "fuzzystrmatch"
 
     # Test names with dashes are escaped correctly.
@@ -9,8 +9,8 @@ class CreateExtension < ActiveRecord::Migration
     create_extension "uuid-ossp"
     drop_extension   "uuid-ossp"
 
-    create_extension "btree_gist", :schema_name => 'demography'
-    add_index :pets, :user_id, :using => :gist, :name => 'index_pets_on_user_id_gist'
-    add_index :pets, "to_tsvector('english', name)", :using => :gist, :name => 'index_pets_on_to_tsvector_name_gist'
+    create_extension "btree_gist", schema_name: 'demography'
+    add_index :pets, :user_id, using: :gist, name: 'index_pets_on_user_id_gist'
+    add_index :pets, "to_tsvector('english', name)", using: :gist, name: 'index_pets_on_to_tsvector_name_gist'
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -17,8 +17,8 @@ ActiveRecord::Schema.define(version: 20190320025645) do
   create_schema "later"
   create_schema "latest"
 
-  create_extension "fuzzystrmatch", :version => "1.1"
-  create_extension "btree_gist", :schema_name => "demography", :version => "1.2"
+  create_extension "fuzzystrmatch", version: "1.1"
+  create_extension "btree_gist", schema_name: "demography", version: "1.2"
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 20190320025645) do
     t.datetime "updated_at"
   end
 
-  add_index "books", "((((tags -> 'attrs'::text) ->> 'edition'::text))::integer)", :name => "books_tags_json_index", :skip_column_quoting => true
-  add_index "books", ["title varchar_pattern_ops"], :name => "index_books_on_title_varchar_pattern_ops"
+  add_index "books", "((((tags -> 'attrs'::text) ->> 'edition'::text))::integer)", name: "books_tags_json_index", skip_column_quoting: true
+  add_index "books", ["title varchar_pattern_ops"], name: "index_books_on_title_varchar_pattern_ops"
 
   create_table "breeds", force: :cascade do |t|
     t.string   "name"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20190320025645) do
     t.integer "name"
   end
 
-  add_index "demography.cities", ["country_id"], :name => "index_demography_cities_on_country_id"
+  add_index "demography.cities", ["country_id"], name: "index_demography_cities_on_country_id"
 
   create_table "demography.citizens", force: :cascade do |t|
     t.integer  "country_id"
@@ -77,7 +77,7 @@ ActiveRecord::Schema.define(version: 20190320025645) do
     t.boolean  "active",     default: false, null: false
   end
 
-  add_index "demography.citizens", ["country_id", "user_id"], :name => "index_demography_citizens_on_country_id_and_user_id", :unique => true, :where => "active"
+  add_index "demography.citizens", ["country_id", "user_id"], name: "index_demography_citizens_on_country_id_and_user_id", unique: true, where: "active"
 
   create_table "demography.countries", force: :cascade do |t|
     t.string   "name"
@@ -112,15 +112,15 @@ ActiveRecord::Schema.define(version: 20190320025645) do
     t.boolean "active",     default: true
   end
 
-  add_index "pets", ["breed_id"], :name => "index_pets_on_breed_id"
-  add_index "pets", ["color"], :name => "index_pets_on_color"
-  add_index "pets", ["country_id"], :name => "index_pets_on_country_id"
-  add_index "pets", ["lower(name) DESC NULLS LAST"], :name => "index_pets_on_lower_name_desc_nulls_last"
-  add_index "pets", ["lower(name)"], :name => "index_pets_on_lower_name"
-  add_index "pets", ["to_tsvector('english'::regconfig, name)"], :name => "index_pets_on_to_tsvector_name_gist", :using => "gist"
-  add_index "pets", ["upper(color)"], :name => "index_pets_on_upper_color", :where => "(name IS NULL)"
-  add_index "pets", ["user_id"], :name => "index_pets_on_user_id"
-  add_index "pets", ["user_id"], :name => "index_pets_on_user_id_gist", :using => "gist"
+  add_index "pets", ["breed_id"], name: "index_pets_on_breed_id"
+  add_index "pets", ["color"], name: "index_pets_on_color"
+  add_index "pets", ["country_id"], name: "index_pets_on_country_id"
+  add_index "pets", ["lower(name) DESC NULLS LAST"], name: "index_pets_on_lower_name_desc_nulls_last"
+  add_index "pets", ["lower(name)"], name: "index_pets_on_lower_name"
+  add_index "pets", ["to_tsvector('english'::regconfig, name)"], name: "index_pets_on_to_tsvector_name_gist", using: "gist"
+  add_index "pets", ["upper(color)"], name: "index_pets_on_upper_color", where: "(name IS NULL)"
+  add_index "pets", ["user_id"], name: "index_pets_on_user_id"
+  add_index "pets", ["user_id"], name: "index_pets_on_user_id_gist", using: "gist"
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -130,12 +130,12 @@ ActiveRecord::Schema.define(version: 20190320025645) do
     t.datetime "updated_at"
   end
 
-  add_index "users", ["email"], :name => "index_users_on_email"
-  add_index "users", ["name"], :name => "index_users_on_name"
+  add_index "users", ["email"], name: "index_users_on_email"
+  add_index "users", ["name"], name: "index_users_on_name"
 
-  add_foreign_key "demography.cities", "demography.countries", :exclude_index => true
-  add_foreign_key "demography.citizens", "users", :exclude_index => true
-  add_foreign_key "pets", "users", :exclude_index => true
+  add_foreign_key "demography.cities", "demography.countries", exclude_index: true
+  add_foreign_key "demography.citizens", "users", exclude_index: true
+  add_foreign_key "pets", "users", exclude_index: true
   create_view "demography.citizens_view", <<-SQL
      SELECT citizens.id,
     citizens.country_id,

--- a/spec/foreign_keys_spec.rb
+++ b/spec/foreign_keys_spec.rb
@@ -9,7 +9,7 @@ describe 'Foreign keys' do
     end
 
     # AddForeignKeys migration
-    #   add_foreign_key 'demography.citizens', 'users', :exclude_index => true
+    #   add_foreign_key 'demography.citizens', 'users', exclude_index: true
     it 'should not add an index on the foreign key when :exclude_index is true' do
       PgSaurus::Explorer.index_exists?('demography.citizens', :user_id).should == false
     end
@@ -26,7 +26,7 @@ describe 'Foreign keys' do
   describe '#remove_foreign_key' do
     # RemoveForeignKeys migration
     #   remove_foreign_key 'demography.citizens', 'demography.countries'
-    #   remove_foreign_key 'pets', :name => "pets_owner_id_fk"
+    #   remove_foreign_key 'pets', name: "pets_owner_id_fk"
     it 'removes foreign key' do
       PgSaurus::Explorer.has_foreign_key?('demography.citizens', :country_id).should == false
       PgSaurus::Explorer.has_foreign_key?('pets', :owner_id).should == false
@@ -34,15 +34,15 @@ describe 'Foreign keys' do
 
     # RemoveForeignKeys migration
     #   remove_foreign_key 'demography.citizens', 'demography.countries'
-    #   remove_foreign_key 'pets', :name => "pets_owner_id_fk"
+    #   remove_foreign_key 'pets', name: "pets_owner_id_fk"
     it 'removes the index on the foreign key' do
       PgSaurus::Explorer.index_exists?('demography.citizens', :country_id).should == false
       PgSaurus::Explorer.index_exists?('pets', :owner_id).should == false
     end
 
     # RemoveForeignKeys migration
-    #   remove_foreign_key 'pets', 'demography.countries', :exclude_index => true
-    #   remove_foreign_key 'pets', :name => "pets_breed_id_fk", :exclude_index => true
+    #   remove_foreign_key 'pets', 'demography.countries', exclude_index: true
+    #   remove_foreign_key 'pets', name: "pets_breed_id_fk", exclude_index: true
     it 'should remove foreign key but not remove the index when :exclude_index is true' do
       PgSaurus::Explorer.has_foreign_key?('pets', :country_id).should == false
       PgSaurus::Explorer.has_foreign_key?('pets', :breed_id).should == false
@@ -53,7 +53,7 @@ describe 'Foreign keys' do
     it 'should not raise an exception if the index does not exist' do
       expect {
         connection = ActiveRecord::Base::connection
-        connection.add_foreign_key 'pets', 'demography.citizens', :exclude_index => true
+        connection.add_foreign_key 'pets', 'demography.citizens', exclude_index: true
         connection.remove_foreign_key 'pets', 'demography.citizens'
       }.not_to raise_error
     end

--- a/spec/indexes_spec.rb
+++ b/spec/indexes_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Indexes' do
   describe '#add_index' do
     it 'is built with the :where option' do
-      index_options = {:where => "active"}
+      index_options = {where: "active"}
 
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
 
@@ -17,7 +17,7 @@ describe 'Indexes' do
     end
 
     it 'allows indexes with expressions using functions with multiple arguments' do
-      ActiveRecord::Migration.add_index(:pets, "to_tsvector('english', name)", :using => 'gin')
+      ActiveRecord::Migration.add_index(:pets, "to_tsvector('english', name)", using: 'gin')
 
       PgSaurus::Explorer.index_exists?(:pets, "gin(to_tsvector('english', name))" ).should be true
     end
@@ -25,7 +25,7 @@ describe 'Indexes' do
     it 'allows indexes with expressions using functions with multiple arguments as dumped' do
       ActiveRecord::Migration.add_index(:pets,
                                         "to_tsvector('english'::regconfig, name)",
-                                        :using => 'gin')
+                                        using: 'gin')
 
       PgSaurus::Explorer.index_exists?(:pets, "gin(to_tsvector('english', name))" ).should be true
     end
@@ -39,7 +39,7 @@ describe 'Indexes' do
     end
 
     it "allows partial indexes with expressions" do
-      opts = {:where => 'color IS NULL'}
+      opts = {where: 'color IS NULL'}
 
       ActiveRecord::Migration.add_index(:pets, ['upper(name)', 'lower(color)'], opts)
       PgSaurus::Explorer.index_exists?(:pets, ['upper(name)', 'lower(color)'], opts).should be true
@@ -64,7 +64,7 @@ describe 'Indexes' do
 
     it 'removes indexes built with the :where option' do
 
-      index_options = {:where => "active"}
+      index_options = {where: "active"}
 
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       ActiveRecord::Migration.remove_index(:pets, :name)
@@ -87,7 +87,7 @@ describe 'Indexes' do
     end
 
     it 'is true for a valid set of options' do
-      index_options = {:unique => true, :where => 'active'}
+      index_options = {unique: true, where: 'active'}
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id, :user_id],
                                       index_options
@@ -95,9 +95,9 @@ describe 'Indexes' do
     end
 
     it 'is true for a valid set of options including name' do
-      index_options = { :unique => true,
-                        :where  => 'active',
-                        :name   => 'index_demography_citizens_on_country_id_and_user_id' }
+      index_options = { unique: true,
+                        where: 'active',
+                        name: 'index_demography_citizens_on_country_id_and_user_id' }
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id, :user_id],
                                       index_options
@@ -105,7 +105,7 @@ describe 'Indexes' do
     end
 
     it 'is false for a subset of valid options' do
-      index_options = {:where => 'active'}
+      index_options = {where: 'active'}
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id, :user_id],
                                       index_options
@@ -113,7 +113,7 @@ describe 'Indexes' do
     end
 
     it 'is false for invalid options' do
-      index_options = {:where => 'active'}
+      index_options = {where: 'active'}
       PgSaurus::Explorer.index_exists?('demography.citizens',
                                       [:country_id],
                                       index_options
@@ -121,37 +121,37 @@ describe 'Indexes' do
     end
 
     it 'is true for a :where clause that includes boolean comparison' do
-      index_options = {:where => 'active'}
+      index_options = {where: 'active'}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
     it 'is true for a :where clause that includes text comparison' do
-      index_options = {:where => "color = 'black'"}
+      index_options = {where: "color = 'black'"}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
     it 'is true for a :where clause that includes NULL comparison' do
-      index_options = {:where => 'color IS NULL'}
+      index_options = {where: 'color IS NULL'}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
     it 'is true for a :where clause that includes integer comparison' do
-      index_options = {:where => 'id = 4'}
+      index_options = {where: 'id = 4'}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
     it 'is true for a compound :where clause' do
-      index_options = {:where => "id = 4 and color = 'black' and active"}
+      index_options = {where: "id = 4 and color = 'black' and active"}
       ActiveRecord::Migration.add_index(:pets, :name, index_options)
       PgSaurus::Explorer.index_exists?(:pets, :name, index_options).should be true
     end
 
     it 'is true for concurrently created index' do
-      index_options = {:concurrently => true}
+      index_options = {concurrently: true}
       PgSaurus::Explorer.index_exists?(:users, :email, index_options).should be true
     end
 

--- a/spec/lib/core_ext/connection_adapters/abstract/schema_statements_spec.rb
+++ b/spec/lib/core_ext/connection_adapters/abstract/schema_statements_spec.rb
@@ -14,7 +14,7 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
           query.should == expected_query
         end
 
-        ActiveRecord::Migration.add_index :users, :phone_number, :concurrently => true
+        ActiveRecord::Migration.add_index :users, :phone_number, concurrently: true
         ActiveRecord::Migration.process_postponed_queries
       end
     end
@@ -58,7 +58,7 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
       expect(ActiveRecord::Base.connection).
         to receive(:index_exists?).once.and_return(true)
 
-      ActiveRecord::Migration.add_index :users, :phone_number, :concurrently => true
+      ActiveRecord::Migration.add_index :users, :phone_number, concurrently: true
 
       expect {
         ActiveRecord::Migration.process_postponed_queries

--- a/spec/lib/pg_saurus/migration/command_recorder_spec.rb
+++ b/spec/lib/pg_saurus/migration/command_recorder_spec.rb
@@ -38,9 +38,9 @@ describe PgSaurus::Migration::CommandRecorder do
     it '.invert_create_functions' do
       expect(
         command_recorder_stub.invert_create_function(
-          [ 'pets_not_empty()', :boolean, 'FU', { :schema => 'public' } ]
+          [ 'pets_not_empty()', :boolean, 'FU', { schema: 'public' } ]
         )
-      ).to eq([ :drop_function, [ "pets_not_empty()", { :schema => "public" } ] ])
+      ).to eq([ :drop_function, [ "pets_not_empty()", { schema: "public" } ] ])
     end
 
   end
@@ -73,7 +73,7 @@ describe PgSaurus::Migration::CommandRecorder do
     end
 
     it '.invert_set_column_comments' do
-      command_recorder_stub.invert_set_column_comments([:foo, {:bar => :baz}]).
+      command_recorder_stub.invert_set_column_comments([:foo, {bar: :baz}]).
                             should == [:remove_column_comments, [:foo, :bar]]
     end
 

--- a/spec/lib/pg_saurus/tools_spec.rb
+++ b/spec/lib/pg_saurus/tools_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe PgSaurus::Tools do
   describe '#move_table_to_schema' do
     it 'moves table to another schema' do
-      Pet.create!(:name => "Flaaffy", :color => "#FFAABB")
+      Pet.create!(name: "Flaaffy", color: "#FFAABB")
       PgSaurus::Explorer.table_exists?('public.pets').should == true
 
       # Move table
@@ -17,7 +17,7 @@ describe PgSaurus::Tools do
       PgSaurus::Explorer.table_exists?('demography.pets').should == false
 
       # Make sure data is not lost
-      Pet.where(:name => "Flaaffy", :color => "#FFAABB").size.should == 1
+      Pet.where(name: "Flaaffy", color: "#FFAABB").size.should == 1
     end
   end
 


### PR DESCRIPTION
A simple foray into rubocop validation. 1.9 hash syntax as the standard is pretty widespread, so generated code would be better off using it.