### PR TITLE
22253 dump create_schema_if_not_exists

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,4 +54,6 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = 'spec/**/*_spec.rb'
 end
 
+task default: :spec
+
 task 'spec' => ['db:drop', 'db:create', 'db:migrate', 'app:db:test:load']

--- a/lib/pg_saurus/schema_dumper/schema_methods.rb
+++ b/lib/pg_saurus/schema_dumper/schema_methods.rb
@@ -21,7 +21,7 @@ module PgSaurus::SchemaDumper::SchemaMethods
 
   # Generates code to create schema.
   def schema(schema_name, stream)
-    stream << "  create_schema \"#{schema_name}\"\n"
+    stream << "  create_schema_if_not_exists \"#{schema_name}\"\n"
   end
   private :schema
 end

--- a/spec/active_record/schema_dumper_spec.rb
+++ b/spec/active_record/schema_dumper_spec.rb
@@ -11,12 +11,12 @@ describe ActiveRecord::SchemaDumper do
 
     context 'Schemas' do
       it 'dumps schemas' do
-        @dump.should =~ /create_schema "demography"/
-        @dump.should =~ /create_schema "later"/
-        @dump.should =~ /create_schema "latest"/
+        @dump.should =~ /create_schema_if_not_exists "demography"/
+        @dump.should =~ /create_schema_if_not_exists "later"/
+        @dump.should =~ /create_schema_if_not_exists "latest"/
       end
       it 'dumps schemas in alphabetical order' do
-        @dump.should =~ /create_schema "demography".*create_schema "later".*create_schema "latest"/m
+        @dump.should =~ /create_schema_if_not_exists "demography".*create_schema_if_not_exists "later".*create_schema_if_not_exists "latest"/m
       end
     end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -13,9 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20190320025645) do
 
-  create_schema "demography"
-  create_schema "later"
-  create_schema "latest"
+  create_schema_if_not_exists "demography"
+  create_schema_if_not_exists "later"
+  create_schema_if_not_exists "latest"
 
   create_extension "fuzzystrmatch", :version => "1.1"
   create_extension "btree_gist", :schema_name => "demography", :version => "1.2"


### PR DESCRIPTION
**Link to Acunote task**:
- [Task 22253](https://integracredit.acunote.com/projects/52849/tasks/22253)

**Description of changes this PR makes**:
- Dump `create_schema_if_not_exists` to `schema.rb` as default for both `create_schema` and `create_schema_if_not_exists`.