### PR TITLE
8706 skip execution of schemaa creation SQL if schema already exists

### DIFF
--- a/lib/pg_saurus/tools.rb
+++ b/lib/pg_saurus/tools.rb
@@ -19,8 +19,10 @@ module PgSaurus
     #
     # @return [void]
     def create_schema_if_not_exists(schema_name)
-      sql = %{CREATE SCHEMA IF NOT EXISTS "#{schema_name}"}
-      connection.execute sql
+      unless schemas.include?(schema_name.to_s)
+        sql = %{CREATE SCHEMA "#{schema_name}"}
+        connection.execute sql
+      end
     end
 
     # Ensure schema does not exists.

--- a/spec/lib/pg_saurus/tools_spec.rb
+++ b/spec/lib/pg_saurus/tools_spec.rb
@@ -24,7 +24,7 @@ describe PgSaurus::Tools do
   let(:connection) { PgSaurus::Tools.send(:connection) }
 
   it ".create_schema_if_not_exists" do
-    expect(connection).to receive(:execute).with('CREATE SCHEMA IF NOT EXISTS "someschema"')
+    expect(connection).to receive(:execute).with('CREATE SCHEMA "someschema"')
     PgSaurus::Tools.create_schema_if_not_exists("someschema")
   end
 


### PR DESCRIPTION
This is a reversion to previous behavior. Calling `CREATE SCHEMA IF NOT EXISTS` throws a permission error if you do not have access (in the case of a shared schema) while the original code avoids the call based on metadata.