### PR TITLE
Support Postgres 11 and over

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ version2x = (RUBY_VERSION =~ /^2\.\d/)
 # https://github.com/ged/ruby-pg/blob/master/History.rdoc
 # https://bitbucket.org/ged/ruby-pg/wiki/Home
 
-# pg >= 1.0.0 doesn't work with Rails at the moment. It's a Rails bug.
 gem "pg"
+gem "psych", "~> 3"
 
 gem "railties",      rails_version
 gem "activemodel",   rails_version

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
@@ -113,7 +113,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   def pg_extensions
     # Check postgresql version to not break on Postgresql < 9.1 during schema dump
     pg_version_str = select_value('SELECT version()')
-    return {} unless pg_version_str =~ /^PostgreSQL (\d+).(\d+)/ && ($1.to_i >= 9) && ($2.to_i > 1)
+    return {} unless pg_version_str =~ /^PostgreSQL (\d+).(\d+)/ && ($1.to_i >= 9) && ($2.to_i >= 1)
 
     sql = <<-SQL
       SELECT pge.extname AS ext_name, pgn.nspname AS schema_name, pge.extversion AS ext_version

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
@@ -112,8 +112,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   # @return [Hash{String => Hash{Symbol => String}}] A list of loaded extensions with their options
   def pg_extensions
     # Check postgresql version to not break on Postgresql < 9.1 during schema dump
-    pg_version_str = select_value('SELECT version()')
-    return {} unless pg_version_str =~ /^PostgreSQL (\d+).(\d+)/ && ($1.to_i >= 9) && ($2.to_i >= 1)
+    return {} if (::PgSaurus::Engine.pg_server_version <=> [9, 1]) < 0
 
     sql = <<-SQL
       SELECT pge.extname AS ext_name, pgn.nspname AS schema_name, pge.extversion AS ext_version

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/extension_methods.rb
@@ -113,7 +113,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::ExtensionMethods
   def pg_extensions
     # Check postgresql version to not break on Postgresql < 9.1 during schema dump
     pg_version_str = select_value('SELECT version()')
-    return {} unless pg_version_str =~ /^PostgreSQL (\d+\.\d+.\d+)/ && ($1 >= '9.1')
+    return {} unless pg_version_str =~ /^PostgreSQL (\d+).(\d+)/ && ($1.to_i >= 9) && ($2.to_i > 1)
 
     sql = <<-SQL
       SELECT pge.extname AS ext_name, pgn.nspname AS schema_name, pge.extversion AS ext_version

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods.rb
@@ -21,7 +21,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::FunctionMethods
   #
   # @return [Integer]
   def self._pg_major
-    @@_pg_major ||= PgSaurus::ConnectionAdapters::PostgreSQLAdapter::FunctionMethods.split(".").first.to_i
+    @@_pg_major ||= PgSaurus::ConnectionAdapters::PostgreSQLAdapter::FunctionMethods._pg_version.split(".").first.to_i
   end
 
   # Return a list of defined DB functions. Ignore function definitions that can't be parsed.

--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/function_methods.rb
@@ -18,7 +18,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::FunctionMethods
         pg_catalog.pg_get_function_result(p.oid) AS "Returning",
        CASE
         WHEN #{pg_major >= 11 ? "p.prokind = 'w'" : "p.proiswindow"} THEN 'window'
-        WHEN p.prorettype = 'pg_catalog.trigger'::pg_catalog.regtype  THEN 'trigger'
+        WHEN p.prorettype = 'pg_catalog.trigger'::pg_catalog.regtype THEN 'trigger'
         ELSE 'normal'
        END   AS "Type",
        p.oid AS "Oid"

--- a/lib/pg_saurus/engine.rb
+++ b/lib/pg_saurus/engine.rb
@@ -2,6 +2,16 @@ module PgSaurus
   # :nodoc:
   class Engine < Rails::Engine
 
+    # Postgres server version.
+    #
+    # @return [Array<Integer>]
+    def self.pg_server_version
+      @pg_server_version ||=
+        ::ActiveRecord::Base.connection.
+          select_value('SHOW SERVER_VERSION').
+          split('.')[0..1].map(&:to_i)
+    end
+
     initializer "pg_saurus" do
       ActiveSupport.on_load(:active_record) do
         # load monkey patches

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 2019_08_01_025445) do
   create_schema_if_not_exists "latest"
 
   create_extension "fuzzystrmatch", :version => "1.1"
-  create_extension "btree_gist", :schema_name => "demography", :version => "1.2"
+  create_extension "btree_gist", :schema_name => "demography", :version => "1.5"
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"


### PR DESCRIPTION
I've tested these changes on some of my projects and they seem to be working.

Documentation for [`p.prokind`](https://www.postgresql.org/docs/11/catalog-pg-proc.html) specifies that the type is `char` so there won't be any curveballs with multiple characters being returned, i.e. nothing like `p.prokind = 'aw'`.