### PR TITLE
Cover Postgres 12+ `CREATE TRIGGER` internal definition

### DIFF
--- a/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods.rb
+++ b/lib/pg_saurus/connection_adapters/postgresql_adapter/trigger_methods.rb
@@ -95,7 +95,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
 
   # Parse the condition from the trigger definition.
   def parse_condition(trigger_definition)
-    trigger_definition[/WHEN[\s](.*?)[\s]EXECUTE[\s]PROCEDURE/m, 1]
+    trigger_definition[/WHEN[\s](.*?)[\s]EXECUTE[\s](FUNCTION|PROCEDURE)/m, 1]
   end
   private :parse_condition
 
@@ -107,7 +107,7 @@ module PgSaurus::ConnectionAdapters::PostgreSQLAdapter::TriggerMethods
 
   # Parse the procedure name from the trigger definition.
   def parse_proc_name(trigger_definition)
-    trigger_definition[/EXECUTE[\s]PROCEDURE[\s](.*?)$/m,1]
+    trigger_definition[/EXECUTE[\s](FUNCTION|PROCEDURE)[\s](.*?)$/m, 2]
   end
   private :parse_proc_name
 


### PR DESCRIPTION
I noticed that triggers are not being properly parsed/created with Postgres 12.x.
The regular specs should cover this if run with either Postgres 9.6 or 12. I'm not sure how they were passing before this change.

Manual example:

```sql
CREATE TABLE COMPANY(
   ID INT PRIMARY KEY     NOT NULL,
   NAME           TEXT    NOT NULL,
   AGE            INT     NOT NULL,
   ADDRESS        CHAR(50),
   SALARY         REAL
);

CREATE OR REPLACE FUNCTION validate_record_count()
RETURNS trigger
LANGUAGE plpgsql
AS $function$
BEGIN
    IF ( SELECT count(*) FROM company ) > 3
    THEN
        RAISE EXCEPTION 'Count is greater than 3!';
    END IF;
    RETURN NULL;
END;
$function$
;


CREATE TRIGGER my_trigger
  AFTER INSERT OR UPDATE
  ON company
  FOR EACH ROW
  EXECUTE PROCEDURE validate_record_count()
;

SELECT
    pg_catalog.pg_get_triggerdef(t.oid, true) as trigger_definition
FROM pg_catalog.pg_trigger t
WHERE t.tgname = 'my_trigger'
;
```
On Postgres 9.6 the last query returns the following:
```
                                            trigger_definition
----------------------------------------------------------------------------------------------------------
 CREATE TRIGGER my_trigger AFTER INSERT OR UPDATE ON company FOR EACH ROW EXECUTE PROCEDURE validate_record_count()
```
and on Postgres 12, the last query returns this:
```
                                            trigger_definition
-----------------------------------------------------------------------------------------------------------
 CREATE TRIGGER my_trigger AFTER INSERT OR UPDATE ON company FOR EACH ROW EXECUTE FUNCTION validate_record_count()
```