### PR TITLE
Add set_role and keep_default role checks

### DIFF
--- a/lib/pg_saurus/errors.rb
+++ b/lib/pg_saurus/errors.rb
@@ -7,4 +7,10 @@ module PgSaurus
 
   # Raised if config.ensure_role_set = true, but migration have no role set.
   class RoleNotSetError < Error; end
+
+  # Raised if set_role used for data change migration.
+  class UseKeepDefaultRoleError < Error; end
+
+  # Raised if keep_default_role used for structure change migration.
+  class UseSetRoleError < Error; end
 end

--- a/lib/pg_saurus/migration/set_role_method.rb
+++ b/lib/pg_saurus/migration/set_role_method.rb
@@ -13,7 +13,7 @@ module PgSaurus
         #
         # @param role [String]
         def set_role(role)
-          if const_defined?("SeedMigrator".to_s) && self.ancestors.include?(SeedMigrator)
+          if const_defined?("SeedMigrator") && self.ancestors.include?(SeedMigrator)
             msg = <<~MSG
               Use keep_default_role instead of set_role for data change migration #{self}
 

--- a/lib/pg_saurus/migration/set_role_method.rb
+++ b/lib/pg_saurus/migration/set_role_method.rb
@@ -42,7 +42,7 @@ module PgSaurus
 
         # Prevents raising exception when ensure_role_set=true and no role is set.
         def keep_default_role
-          if const_defined?("SeedMigrator".to_s) && !self.ancestors.include?(SeedMigrator)
+          if const_defined?("SeedMigrator") && !self.ancestors.include?(SeedMigrator)
             msg = <<~MSG
               Use set_role instead of keep_default_role for structure migration #{self}
 

--- a/lib/pg_saurus/migration/set_role_method.rb
+++ b/lib/pg_saurus/migration/set_role_method.rb
@@ -15,8 +15,10 @@ module PgSaurus
         def set_role(role)
           if const_defined?("SeedMigrator".to_s) && self.ancestors.include?(SeedMigrator)
             msg = <<~MSG
-              Use keep_default_role instead of set_role for data change migration #{self}\n
-              Example:\n
+              Use keep_default_role instead of set_role for data change migration #{self}
+
+              Example:
+
                 class PopulateExample < ActiveRecord::Migration
                   include #{self.ancestors[1]}
 
@@ -29,7 +31,7 @@ module PgSaurus
                   def down
                     revert_update "populate_example_data_update"
                   end
-                end\n
+                end
             MSG
 
             raise PgSaurus::UseKeepDefaultRoleError, msg
@@ -42,8 +44,10 @@ module PgSaurus
         def keep_default_role
           if const_defined?("SeedMigrator".to_s) && !self.ancestors.include?(SeedMigrator)
             msg = <<~MSG
-              Use set_role instead of keep_default_role for structure migration #{self}\n
-              Example:\n
+              Use set_role instead of keep_default_role for structure migration #{self}
+
+              Example:
+
                 class CreateExamples < ActiveRecord::Migration
                   set_role "superhero"
 
@@ -54,7 +58,7 @@ module PgSaurus
                   def down
                     ...
                   end
-                end\n
+                end
             MSG
 
             raise PgSaurus::UseSetRoleError, msg

--- a/spec/lib/pg_saurus/migration_spec.rb
+++ b/spec/lib/pg_saurus/migration_spec.rb
@@ -30,6 +30,20 @@ describe ActiveRecord::Migration[5.2] do
 
         migration.exec_migration(conn, :up)
       end
+
+      context "for data change migration" do
+        it "raises an error" do
+          expect {
+            module SeedMigrator; end
+
+            class TestMigration < described_class
+              include SeedMigrator
+
+              set_role "mikki"
+            end
+          }.to raise_error(PgSaurus::UseKeepDefaultRoleError)
+        end
+      end
     end
 
     context "role is not set" do
@@ -49,17 +63,33 @@ describe ActiveRecord::Migration[5.2] do
 
         context "keep_default_role was called" do
           before do
+            module SeedMigrator; end
+
             class TestMigration < described_class
+              include SeedMigrator
+
               keep_default_role
             end
           end
 
-        it "executes migrations" do
-          migration = TestMigration.new
+          it "executes migrations" do
+            migration = TestMigration.new
 
-          expect(migration).to receive(:up)
-          migration.exec_migration(conn, :up)
-        end
+            expect(migration).to receive(:up)
+            migration.exec_migration(conn, :up)
+          end
+
+          context "for structure change migration" do
+            it "raises an error" do
+              expect {
+                module SeedMigrator; end
+
+                class TestMigrations < described_class
+                  keep_default_role
+                end
+              }.to raise_error(PgSaurus::UseSetRoleError)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## Description
* raise errors if set role or keep default role used in wrong migration.

## Manual Test Plan
* create data change migration with `set_role` and run it (customer_service);
```ruby
class Test < ActiveRecord::Migration[5.2]
  include DataUpdate

  set_role "superhero"

  def up
    apply_update "populate_example_data_update"
  end

  def down
    revert_update "populate_example_data_update"
  end
end
```
* error should be raised;
```
Caused by:
PgSaurus::UseKeepDefaultRoleError: Use keep_default_role instead of set_role for data change migration Test
```
* create structure change migration with `keep_default_role` and run it (customer_service);
```ruby
class Test < ActiveRecord::Migration[5.2]
  keep_default_role

  def up
    add_index :customers, :created_at
  end

  def down
    remove_index :customers, :created_at
  end
end
```
* error should be raised.
```
Caused by:
PgSaurus::UseSetRoleError: Use set_role instead of keep_default_role for structure migration Test
```