### PR TITLE
A fix for dumping database functions with return type 'table'

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -12,7 +12,7 @@ SimpleCov.start do
   # Fail the build when coverage is weak:
   at_exit do
     SimpleCov.result.format!
-    threshold, actual = 98.468, SimpleCov.result.covered_percent
+    threshold, actual = 98.481, SimpleCov.result.covered_percent
     if actual < threshold
       msg = "\nLow coverage: "
       msg << red("#{actual}%")

--- a/lib/pg_saurus/connection_adapters/abstract_adapter/schema_methods.rb
+++ b/lib/pg_saurus/connection_adapters/abstract_adapter/schema_methods.rb
@@ -13,6 +13,7 @@ module PgSaurus::ConnectionAdapters::AbstractAdapter::SchemaMethods
     super(*extract_table_options(table_name, options))
   end
 
+  # Extract the table-specific options for the given table name from the options.
   def extract_table_options(table_name, options)
     options     = options.dup
     schema_name = options.delete(:schema)

--- a/lib/pg_saurus/schema_dumper/function_methods.rb
+++ b/lib/pg_saurus/schema_dumper/function_methods.rb
@@ -15,7 +15,7 @@ module PgSaurus::SchemaDumper::FunctionMethods
   # Writes out a command to create each detected function.
   def dump_functions(stream)
     @connection.functions.each do |function|
-      statement = "  create_function '#{function.name}', :#{function.returning}, <<-FUNCTION_DEFINITION.gsub(/^[\s]{4}/, ''), volatility: :#{function.volatility}"
+      statement = "  create_function '#{function.name}', '#{function.returning}', <<-FUNCTION_DEFINITION.gsub(/^[\s]{4}/, ''), volatility: :#{function.volatility}"
       statement << "\n#{function.definition.split("\n").map{|line| "    #{line}" }.join("\n")}"
       statement << "\n  FUNCTION_DEFINITION\n\n"
 

--- a/spec/active_record/schema_dumper_spec.rb
+++ b/spec/active_record/schema_dumper_spec.rb
@@ -113,6 +113,10 @@ describe ActiveRecord::SchemaDumper do
       it 'dumps function definitions' do
         @dump.should =~ /create_function 'public.pets_not_empty\(\)'/
       end
+
+      it "dumps function definitions returning result sets" do
+        @dump.should =~ / create_function 'public.select_authors\(\)', 'TABLE\(author_id integer\)'/
+      end
     end
 
     context 'Triggers' do

--- a/spec/dummy/db/migrate/20220709040946_add_function_returning_a_table_type.rb
+++ b/spec/dummy/db/migrate/20220709040946_add_function_returning_a_table_type.rb
@@ -1,0 +1,11 @@
+class AddFunctionReturningATableType < ActiveRecord::Migration[6.1]
+  def change
+    create_function 'select_authors()', "TABLE (author_id INTEGER)", <<-FUNCTION.gsub(/^[\s]{6}/, ""), replace: false
+      BEGIN
+        RETURN query (
+          SELECT author_id FROM books
+        );
+      END;
+    FUNCTION
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_01_025445) do
+ActiveRecord::Schema.define(version: 2022_07_09_040946) do
 
   create_schema_if_not_exists "demography"
   create_schema_if_not_exists "later"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 2019_08_01_025445) do
   enable_extension "fuzzystrmatch"
   enable_extension "plpgsql"
 
-  create_function 'public.pets_not_empty()', :boolean, <<-FUNCTION_DEFINITION.gsub(/^[ ]{4}/, ''), volatility: :volatile
+  create_function 'public.pets_not_empty()', 'boolean', <<-FUNCTION_DEFINITION.gsub(/^[ ]{4}/, ''), volatility: :volatile
     BEGIN
       IF (SELECT COUNT(*) FROM pets) > 0
       THEN
@@ -35,9 +35,17 @@ ActiveRecord::Schema.define(version: 2019_08_01_025445) do
     END;
   FUNCTION_DEFINITION
 
-  create_function 'public.pets_not_empty_trigger_proc()', :trigger, <<-FUNCTION_DEFINITION.gsub(/^[ ]{4}/, ''), volatility: :immutable
+  create_function 'public.pets_not_empty_trigger_proc()', 'trigger', <<-FUNCTION_DEFINITION.gsub(/^[ ]{4}/, ''), volatility: :immutable
     BEGIN
       RETURN null;
+    END;
+  FUNCTION_DEFINITION
+
+  create_function 'public.select_authors()', 'TABLE(author_id integer)', <<-FUNCTION_DEFINITION.gsub(/^[ ]{4}/, ''), volatility: :volatile
+    BEGIN
+      RETURN query (
+        SELECT author_id FROM books
+      );
     END;
   FUNCTION_DEFINITION
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema.define(version: 2022_07_09_040946) do
   create_schema_if_not_exists "latest"
 
   create_extension "fuzzystrmatch", version: "1.1"
-  create_extension "btree_gist", schema_name: "demography", version: "1.2"
+  create_extension "btree_gist", schema_name: "demography", version: "1.5"
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"


### PR DESCRIPTION
Return types should be dumped as strings instead of trying to turn them into symbols. Function return types can be more complex then single words.